### PR TITLE
Dev: simplify installing dev environments

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,1 @@
-jupyter-book
-matplotlib
-numpy
-scipy
-pandas
+.[docs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ maintainers = [
   {name = "Joris Vincent", email = "j.vincent@tu-berlin.de"},
 ]
 
+dynamic = ["version"]
+
 requires-python = ">=3.6"
 dependencies = [
   "numpy",
@@ -32,7 +34,7 @@ dependencies = [
   "Pillow"
 ]
 
-dynamic = ["version"]
+
 
 [project.urls]
 repository = "https://github.com/computational-psychology/stimupy.git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,10 @@ dev = [
   "pyupgrade",
   "flake8"
 ]
+docs = [
+  "jupyter-book",
+]
+
 
 [project.urls]
 repository = "https://github.com/computational-psychology/stimupy.git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,13 @@ dependencies = [
 ]
 
 
+[project.optional-dependencies]
+dev = [
+  "pytest",
+  "black",
+  "pyupgrade",
+  "flake8"
+]
 
 [project.urls]
 repository = "https://github.com/computational-psychology/stimupy.git"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pytest
+.[dev,docs]


### PR DESCRIPTION
Modern interpretation and tooling is that `requirements.txt` should be used for *deployment*: to pin exact versions of dependencies (and their dependencies) to reproduce and exact environment (over and over again, e.g., on servers). (see [this SO answer](https://stackoverflow.com/a/28842733), and [this one](https://stackoverflow.com/a/33685899))

For "looser" dependencies, these should just be declared as 'extra'/'dev' dependencies.

Here we specify 2 `extra`s in `pyproject.toml`: `dev` and `docs`, which require extra dependencies. This makes installing a development environment easy:
```
pip install -e ".[dev]"
```
and, if you also want to locally build the documentation:
```
pip install -e ".[dev,docs]"
```

Installing the `dev` extras, means that you can immediately:
- run `pytest` to check that all tests pass
- run `pre-commit run --all-files` to check/ensure linters & formatters, pass

Installing the `docs` extras means that you can immediately run `jupyter-book build --all docs/` to build all the documentation