### PR TITLE
Bugfix: angular frequency in cycles per image

### DIFF
--- a/stimupy/components/waves.py
+++ b/stimupy/components/waves.py
@@ -270,7 +270,8 @@ def sine(
     shape : Sequence[Number, Number], Number, or None (default)
         shape [height, width] of image, in pixels
     frequency : Number, or None (default)
-        spatial frequency of grating, in cycles per degree visual angle
+        spatial frequency of grating, in cycles per degree visual angle.
+        For `distance_metric="angular"`, this is used as cycles-per-image.
     n_phases : int, or None (default)
         number of phases in the grating
     phase_width : Number, or None (default)
@@ -357,7 +358,7 @@ def sine(
             n_phases=n_phases,
             phase_width=phase_width,
             ppd=1,
-            frequency=frequency,
+            frequency=frequency / 360 if frequency is not None else None,
             period=period,
             round_phase_width=round_phase_width,
         )

--- a/stimupy/stimuli/waves.py
+++ b/stimupy/stimuli/waves.py
@@ -1094,7 +1094,7 @@ def sine_angular(
     shape : Sequence[Number, Number], Number, or None (default)
         shape [height, width] of image, in pixels
     frequency : Number, or None (default)
-        spatial frequency of grating, in cycles per degree visual angle
+        spatial frequency of grating, in cycles per image
     n_segments : int, or None (default)
         number of segments
     segment_width : Number, or None (default)
@@ -1214,7 +1214,7 @@ def square_angular(
     shape : Sequence[Number, Number], Number, or None (default)
         shape [height, width] of image, in pixels
     frequency : Number, or None (default)
-        spatial frequency of grating, in cycles per degree visual angle
+        spatial frequency of grating, in cycles per image
     n_segments : int, or None (default)
         number of segments in the grating
     segment_width : Number, or None (default)
@@ -1336,7 +1336,7 @@ def staircase_angular(
     shape : Sequence[Number, Number], Number, or None (default)
         shape [height, width] of image, in pixels
     frequency : Number, or None (default)
-        spatial frequency of grating, in cycles per degree visual angle
+        spatial frequency of grating, in cycles per image
     n_segments : int, or None (default)
         number of segments in the grating
     segment_width : Number, or None (default)


### PR DESCRIPTION
`frequency` argument for waves when `distance_metric="angular"` will now be interpreted as **cycles_per_image**. Thus, divided by 360.
Also clarified in docstrings.

Note: this makes it redundant with `n_segments / 2`