### PR TITLE
fix: two-sided params for `_two_sided`-stimuli

### DIFF
--- a/stimupy/stimuli/bullseyes.py
+++ b/stimupy/stimuli/bullseyes.py
@@ -159,8 +159,8 @@ def circular_two_sided(
         width of a single ring, in degrees
     phase_shift : float
         phase shift of grating in degrees
-    intensity_target : float (optional)
-        intensity value of target ring(s), by default 0.5
+    intensity_target : Sequence[float, float], or float (optional)
+        intensity value of targets, by default 0.5
     intensity_rings : Sequence[Number, ...]
         intensity value for each ring, from inside to out, by default [1,0]
         If fewer intensities are passed than number of radii, cycles through intensities
@@ -399,10 +399,8 @@ def rectangular_two_sided(
     period : "full", "half", "ignore" (default)
         whether to ensure the grating only has "full" periods,
         half "periods", or no guarantees ("ignore")
-    intensity_target : float, or Sequence[float, ...], optional
-        intensity value for each target, by default 0.5.
-        Can specify as many intensities as number of target_indices;
-        If fewer intensities are passed than target_indices, cycles through intensities
+    intensity_target : Sequence[float, float], or float (optional)
+        intensity value of targets, by default 0.5
     intensity_frames : Sequence[float, float]
         min and max intensity of square-wave, by default (0.0, 1.0)
     intensity_background : float (optional)

--- a/stimupy/stimuli/delboeufs.py
+++ b/stimupy/stimuli/delboeufs.py
@@ -122,8 +122,8 @@ def two_sided(
         radius of target circle
     intensity_outer_line : Number
         intensity value of outer circle line (default: 0)
-    intensity_target : Number
-        intensity value of target (default: 0)
+    intensity_target : Sequence[float, float], or float (optional)
+        intensity value of targets, by default 0.5
     intensity_background : Number
         intensity value of background (default: 1)
 
@@ -147,6 +147,10 @@ def two_sided(
         raise ValueError("two_sided() missing argument 'outer_radii' which is not 'None'")
     if target_radius is None:
         raise ValueError("delboeuf() missing argument 'target_radius' which is not 'None'")
+    try:
+        len(intensity_target)
+    except:
+        intensity_target = (intensity_target, intensity_target)
 
     # Resolve resolution
     shape, visual_size, ppd = resolution.resolve(shape=shape, visual_size=visual_size, ppd=ppd)
@@ -158,7 +162,7 @@ def two_sided(
         outer_line_width=outer_line_width,
         target_radius=target_radius,
         intensity_outer_line=intensity_outer_line,
-        intensity_target=intensity_target,
+        intensity_target=intensity_target[0],
         intensity_background=intensity_background,
     )
 
@@ -169,7 +173,7 @@ def two_sided(
         outer_line_width=outer_line_width,
         target_radius=target_radius,
         intensity_outer_line=intensity_outer_line,
-        intensity_target=intensity_target,
+        intensity_target=intensity_target[1],
         intensity_background=intensity_background,
     )
 

--- a/stimupy/stimuli/mueller_lyers.py
+++ b/stimupy/stimuli/mueller_lyers.py
@@ -35,18 +35,18 @@ def mueller_lyer(
         shape [height, width] of grating, in pixels
     outer_lines_length : Number
         length of outer lines in degrees visual angle
-    outer_lines_angle : Number
-        angle of outer lines in degrees. Must be between -180 and 180 degrees.
+    outer_lines_angle : Number (optional)
+        angle of outer lines in degrees, by default 45. Must be between -180 and 180 degrees.
     target_length : Number
         length of target line in degrees visual angle
-    line_width :
+    line_width : Number (optional)
         line width in degrees visual angle; if 0 (default), line width is 1 px
-    intensity_outer_lines : Number
-        intensity value of outer lines
-    intensity_target : Number
-        intensity value of target line
-    intensity_background : Number
-        intensity value of background
+    intensity_outer_lines : Number (optional)
+        intensity value of outer lines, by default 0.01
+    intensity_target : Number (optional)
+        intensity value of target line, by default 0.5
+    intensity_background : Number (optional)
+        intensity value of background, by default 0.0
 
     Returns
     -------
@@ -198,18 +198,20 @@ def two_sided(
         shape [height, width] of grating, in pixels
     outer_lines_length : Number
         length of outer lines in degrees visual angle
-    outer_lines_angle : Number
-        angle of outer lines in degrees. Must be between -180 and 180 degrees.
-    target_length : Number
+    outer_lines_angle : Sequence[Number, Number], or Number (optional)
+        angle of outer lines in degrees, by default 45. Must be between -180 and 180 degrees.
+        If one angle is passed, that is used for left hand display,
+        and right hand display angle is +90 degrees
+    target_length : Sequence[Number, Number], or Number
         length of target line in degrees visual angle
-    line_width :
+    line_width : float
         line width in degrees visual angle; if 0 (default), line width is 1 px
-    intensity_outer_lines : Number
-        intensity value of outer lines
-    intensity_target : Number
-        intensity value of target line
-    intensity_background : Number
-        intensity value of background
+    intensity_outer_lines : Number (optional)
+        intensity value of outer lines, by default 1.0
+    intensity_target : Sequence[Number, Number], or Number (optional)
+        intensity value of target line, by default 0.5
+    intensity_background : Number (optional)
+        intensity value of background, by default 0.0
 
     Returns
     -------
@@ -228,15 +230,30 @@ def two_sided(
     # Resolve resolution
     shape, visual_size, ppd = resolution.resolve(shape=shape, visual_size=visual_size, ppd=ppd)
 
+    try:
+        len(outer_lines_angle)
+    except:
+        outer_lines_angle = (outer_lines_angle, outer_lines_angle + 90)
+
+    try:
+        len(target_length)
+    except:
+        target_length = (target_length, target_length)
+
+    try:
+        len(intensity_target)
+    except:
+        intensity_target = (intensity_target, intensity_target)
+
     stim1 = mueller_lyer(
         visual_size=(visual_size[0], visual_size[1] / 2),
         ppd=ppd,
         outer_lines_length=outer_lines_length,
-        outer_lines_angle=outer_lines_angle,
-        target_length=target_length,
+        outer_lines_angle=outer_lines_angle[0],
+        target_length=target_length[0],
         line_width=line_width,
         intensity_outer_lines=intensity_outer_lines,
-        intensity_target=intensity_target,
+        intensity_target=intensity_target[0],
         intensity_background=intensity_background,
     )
 
@@ -244,11 +261,11 @@ def two_sided(
         visual_size=(visual_size[0], visual_size[1] / 2),
         ppd=ppd,
         outer_lines_length=outer_lines_length,
-        outer_lines_angle=outer_lines_angle + 90,
-        target_length=target_length,
+        outer_lines_angle=outer_lines_angle[1],
+        target_length=target_length[1],
         line_width=line_width,
         intensity_outer_lines=intensity_outer_lines,
-        intensity_target=intensity_target,
+        intensity_target=intensity_target[1],
         intensity_background=intensity_background,
     )
 
@@ -282,7 +299,7 @@ def overview(**kwargs):
     # fmt: off
     stimuli = {
         "mueller_lyer": mueller_lyer(**default_params, **stim_params),
-        "mueller_lyer_2sided": two_sided(**default_params, **stim_params),
+        "mueller_lyer_2sided": two_sided(**default_params, **stim_params, intensity_target=(0.5, 1.0)),
     }
     # fmt: on
 

--- a/stimupy/stimuli/rings.py
+++ b/stimupy/stimuli/rings.py
@@ -63,7 +63,7 @@ def circular_two_sided(
         phase shift of grating in degrees
     target_indices : int or Sequence[int, ] (optional)
         indices of target discs. If not specified, use middle ring (round down)
-    intensity_target : float (optional)
+    intensity_target : Sequence[float, float], or float (optional)
         intensity value of target ring(s), by default 0.5
     intensity_rings : Sequence[Number, ...]
         intensity value for each ring, from inside to out, by default [1,0]
@@ -98,6 +98,11 @@ def circular_two_sided(
     # Resolve resolution
     shape, visual_size, ppd = resolution.resolve(shape=shape, visual_size=visual_size, ppd=ppd)
 
+    try:
+        len(intensity_target)
+    except:
+        intensity_target = (intensity_target, intensity_target)
+
     stim1 = circular(
         visual_size=(visual_size[0], visual_size[1] / 2),
         ppd=ppd,
@@ -106,7 +111,7 @@ def circular_two_sided(
         ring_width=ring_width,
         phase_shift=phase_shift,
         target_indices=target_indices,
-        intensity_target=intensity_target,
+        intensity_target=intensity_target[0],
         intensity_rings=intensity_rings,
         intensity_background=intensity_background,
         origin=origin,
@@ -121,7 +126,7 @@ def circular_two_sided(
         ring_width=ring_width,
         phase_shift=phase_shift,
         target_indices=target_indices,
-        intensity_target=intensity_target,
+        intensity_target=intensity_target[1],
         intensity_rings=intensity_rings[::-1],
         intensity_background=intensity_background,
         origin=origin,
@@ -262,10 +267,8 @@ def rectangular_two_sided(
         intensity value of background, by default 0.5
     target_indices : int, or Sequence[int, ...]
         indices frames where targets will be placed
-    intensity_target : float, or Sequence[float, ...], optional
-        intensity value for each target, by default 0.5.
-        Can specify as many intensities as number of target_indices;
-        If fewer intensities are passed than target_indices, cycles through intensities
+    intensity_target : Sequence[float, float], or float (optional)
+        intensity value of target ring(s), by default 0.5
     origin : "corner", "mean" or "center"
         if "corner": set origin to upper left corner
         if "mean": set origin to hypothetical image center (default)
@@ -293,6 +296,11 @@ def rectangular_two_sided(
     # Resolve resolution
     shape, visual_size, ppd = resolution.resolve(shape=shape, visual_size=visual_size, ppd=ppd)
 
+    try:
+        len(intensity_target)
+    except:
+        intensity_target = (intensity_target, intensity_target)
+
     stim1 = rectangular(
         visual_size=(visual_size[0], visual_size[1] / 2),
         ppd=ppd,
@@ -300,7 +308,7 @@ def rectangular_two_sided(
         n_frames=n_frames,
         frame_width=frame_width,
         phase_shift=phase_shift,
-        intensity_target=intensity_target,
+        intensity_target=intensity_target[0],
         intensity_frames=intensity_frames,
         target_indices=target_indices,
         origin=origin,
@@ -316,7 +324,7 @@ def rectangular_two_sided(
         n_frames=n_frames,
         frame_width=frame_width,
         phase_shift=phase_shift,
-        intensity_target=intensity_target,
+        intensity_target=intensity_target[1],
         intensity_frames=intensity_frames[::-1],
         target_indices=target_indices,
         origin=origin,

--- a/stimupy/stimuli/sbcs.py
+++ b/stimupy/stimuli/sbcs.py
@@ -154,8 +154,8 @@ def two_sided(
         size of the target in degree visual angle (height, width)
     intensity_background : Sequence[Number, Number]
         intensity values for backgrounds
-    intensity_target : float
-        intensity value for target
+    intensity_target : Sequence[float, float], or float (optional)
+        intensity value of targets, by default 0.5
 
     Returns
     -------
@@ -172,6 +172,11 @@ def two_sided(
     if target_size is None:
         raise ValueError("two_sided() missing argument 'target_size' which is not 'None'")
 
+    try:
+        len(intensity_target)
+    except:
+        intensity_target = (intensity_target, intensity_target)
+
     # Resolve resolution
     shape, visual_size, ppd = resolution.resolve(shape=shape, visual_size=visual_size, ppd=ppd)
 
@@ -180,7 +185,7 @@ def two_sided(
         ppd=ppd,
         target_size=target_size,
         intensity_background=intensity_backgrounds[0],
-        intensity_target=intensity_target,
+        intensity_target=intensity_target[0],
     )
 
     stim2 = basic(
@@ -188,7 +193,7 @@ def two_sided(
         ppd=ppd,
         target_size=target_size,
         intensity_background=intensity_backgrounds[1],
-        intensity_target=intensity_target,
+        intensity_target=intensity_target[1],
     )
 
     stim = stack_dicts(stim1, stim2)
@@ -367,8 +372,8 @@ def with_dots_two_sided(
         intensity values for background
     intensity_dots : Sequence[Number, Number]
         intensity values for dots
-    intensity_target : float
-        intensity value for target
+    intensity_target : Sequence[float, float], or float (optional)
+        intensity value of targets, by default 0.5
 
     Returns
     -------
@@ -384,6 +389,11 @@ def with_dots_two_sided(
         Journal of Vision, 8(2), 16-16.
         https://doi.org/10.1167/8.2.16
     """
+
+    try:
+        len(intensity_target)
+    except:
+        intensity_target = (intensity_target, intensity_target)
 
     # Resolve resolution
     try:
@@ -401,7 +411,7 @@ def with_dots_two_sided(
         target_shape=target_shape,
         intensity_background=intensity_backgrounds[0],
         intensity_dots=intensity_dots[0],
-        intensity_target=intensity_target,
+        intensity_target=intensity_target[0],
     )
 
     stim2 = with_dots(
@@ -413,7 +423,7 @@ def with_dots_two_sided(
         target_shape=target_shape,
         intensity_background=intensity_backgrounds[1],
         intensity_dots=intensity_dots[1],
-        intensity_target=intensity_target,
+        intensity_target=intensity_target[1],
     )
 
     stim = stack_dicts(stim1, stim2)
@@ -585,12 +595,12 @@ def dotted_two_sided(
         distance between dots in degree visual angle
     target_shape : int or (int, int)
         target shape defined as the number of dots that fit into the target
-    intensity_background : equence[Number, Number]
+    intensity_background : Sequence[Number, Number]
         intensity values for background
-    intensity_dots : equence[Number, Number]
+    intensity_dots : Sequence[Number, Number]
         intensity values for dots
-    intensity_target : float
-        intensity value for target
+    intensity_target : Sequence[float, float], or float (optional)
+        intensity value of targets, by default 0.5
 
     Returns
     -------
@@ -606,6 +616,11 @@ def dotted_two_sided(
         Journal of Vision, 8(2), 16-16.
         https://doi.org/10.1167/8.2.16
     """
+
+    try:
+        len(intensity_target)
+    except:
+        intensity_target = (intensity_target, intensity_target)
 
     # Resolve resolution
     try:
@@ -623,7 +638,7 @@ def dotted_two_sided(
         target_shape=target_shape,
         intensity_background=intensity_backgrounds[0],
         intensity_dots=intensity_dots[0],
-        intensity_target=intensity_target,
+        intensity_target=intensity_target[0],
     )
 
     stim2 = dotted(
@@ -635,7 +650,7 @@ def dotted_two_sided(
         target_shape=target_shape,
         intensity_background=intensity_backgrounds[1],
         intensity_dots=intensity_dots[1],
-        intensity_target=intensity_target,
+        intensity_target=intensity_target[1],
     )
 
     stim = stack_dicts(stim1, stim2)
@@ -677,4 +692,4 @@ if __name__ == "__main__":
     from stimupy.utils import plot_stimuli
 
     stims = overview()
-    plot_stimuli(stims, mask=True, save=None)
+    plot_stimuli(stims, mask=False, save=None)

--- a/stimupy/stimuli/todorovics.py
+++ b/stimupy/stimuli/todorovics.py
@@ -282,8 +282,8 @@ def rectangle_two_sided(
         distance from cover center to target center in (y, x)
     intensity_background : Sequence[Number, Number]
         intensity values for backgrounds
-    intensity_target : float
-        intensity value for target
+    intensity_target : Sequence[float, float], or float (optional)
+        intensity value of targets, by default 0.5
     intensity_covers : Sequence[Number, Number]
         intensity values for covers
 
@@ -307,6 +307,11 @@ def rectangle_two_sided(
         Lightness and junctions. Perception, 26, 379-395.
     """
 
+    try:
+        len(intensity_target)
+    except:
+        intensity_target = (intensity_target, intensity_target)
+
     # Resolve resolution
     shape, visual_size, ppd = resolution.resolve(shape=shape, visual_size=visual_size, ppd=ppd)
 
@@ -317,7 +322,7 @@ def rectangle_two_sided(
         covers_size=covers_size,
         covers_offset=covers_offset,
         intensity_background=intensity_backgrounds[0],
-        intensity_target=intensity_target,
+        intensity_target=intensity_target[0],
         intensity_covers=intensity_covers[0],
     )
 
@@ -328,7 +333,7 @@ def rectangle_two_sided(
         covers_size=covers_size,
         covers_offset=covers_offset,
         intensity_background=intensity_backgrounds[1],
-        intensity_target=intensity_target,
+        intensity_target=intensity_target[1],
         intensity_covers=intensity_covers[1],
     )
 
@@ -613,8 +618,8 @@ def cross_two_sided(
         size of covers in degrees of visual angle (height, width)
     intensity_backgrounds : Sequence[Number, Number]
         intensity values for backgrounds
-    intensity_target : float
-        intensity value for target
+    intensity_target : Sequence[float, float], or float (optional)
+        intensity value of targets, by default 0.5
     intensity_covers : Sequence[Number, Number]
         intensity values for covers
 
@@ -638,6 +643,11 @@ def cross_two_sided(
         Lightness and junctions. Perception, 26, 379-395.
     """
 
+    try:
+        len(intensity_target)
+    except:
+        intensity_target = (intensity_target, intensity_target)
+
     # Resolve resolution
     shape, visual_size, ppd = resolution.resolve(shape=shape, visual_size=visual_size, ppd=ppd)
 
@@ -648,7 +658,7 @@ def cross_two_sided(
         cross_thickness=cross_thickness,
         covers_size=covers_size,
         intensity_background=intensity_backgrounds[0],
-        intensity_target=intensity_target,
+        intensity_target=intensity_target[0],
         intensity_covers=intensity_covers[0],
     )
 
@@ -659,7 +669,7 @@ def cross_two_sided(
         cross_thickness=cross_thickness,
         covers_size=covers_size,
         intensity_background=intensity_backgrounds[1],
-        intensity_target=intensity_target,
+        intensity_target=intensity_target[1],
         intensity_covers=intensity_covers[1],
     )
 
@@ -793,8 +803,8 @@ def equal_two_sided(
         thickness of target cross in visual angle
     intensity_background : float
         intensity value for background
-    intensity_target : float
-        intensity value for target
+    intensity_target : Sequence[float, float], or float (optional)
+        intensity value of targets, by default 0.5
     intensity_covers : float
         intensity value for covers
 
@@ -817,6 +827,10 @@ def equal_two_sided(
     Todorovic, D. (1997).
         Lightness and junctions. Perception, 26, 379-395.
     """
+    try:
+        len(intensity_target)
+    except:
+        intensity_target = (intensity_target, intensity_target)
 
     # Resolve resolution
     shape, visual_size, ppd = resolution.resolve(shape=shape, visual_size=visual_size, ppd=ppd)
@@ -827,7 +841,7 @@ def equal_two_sided(
         cross_size=cross_size,
         cross_thickness=cross_thickness,
         intensity_background=intensity_backgrounds[0],
-        intensity_target=intensity_target,
+        intensity_target=intensity_target[0],
         intensity_covers=intensity_covers[0],
     )
 
@@ -837,7 +851,7 @@ def equal_two_sided(
         cross_size=cross_size,
         cross_thickness=cross_thickness,
         intensity_background=intensity_backgrounds[1],
-        intensity_target=intensity_target,
+        intensity_target=intensity_target[1],
         intensity_covers=intensity_covers[1],
     )
 


### PR DESCRIPTION
Can now specify two values for several params -- primarily for `intensity_target` -- which will be taken as `(LHS, RHS)`-values. 

Applies to:
- `sbcs`
- `todorovics`
- `rings` & `bullseyes`
- `delboeufs`
- `mueller_lyers`