### PR TITLE
fix: rename `_mask`s

### DIFF
--- a/docs/reference/demos/stimuli/bullseyes.md
+++ b/docs/reference/demos/stimuli/bullseyes.md
@@ -139,7 +139,7 @@ w_int_back = iw.FloatSlider(value=0., min=0, max=1, description="intensity backg
 
 w_ori = iw.Dropdown(value="center", options=['mean', 'corner', 'center'], description="origin")
 w_rot = iw.FloatSlider(value=0, min=0, max=360, description="rotation [deg]")
-w_mask = iw.Dropdown(value=None, options=[None, 'target_mask', 'frame_mask'], description="add mask")
+w_mask = iw.Dropdown(value=None, options=[None, 'target_mask', 'ring_mask'], description="add mask")
 
 w_tint = iw.FloatSlider(value=0.5, min=0, max=1, description="target int")
 

--- a/docs/reference/demos/stimuli/pinwheels.md
+++ b/docs/reference/demos/stimuli/pinwheels.md
@@ -53,7 +53,7 @@ w_tcent = iw.FloatSlider(value=2.5, min=0, max=5, description="target center")
 w_tint = iw.FloatSlider(value=0.5, min=0, max=1, description="target int")
 
 w_ori = iw.Dropdown(value="mean", options=['mean', 'corner', 'center'], description="origin")
-w_mask = iw.Dropdown(value=None, options=[None, 'target_mask', 'wedge_mask'], description="add mask")
+w_mask = iw.Dropdown(value=None, options=[None, 'target_mask', 'segment_mask', 'circle_mask'], description="add mask")
 
 # Layout
 b_im_size = iw.HBox([w_height, w_width, w_ppd])

--- a/docs/reference/demos/stimuli/rings.md
+++ b/docs/reference/demos/stimuli/rings.md
@@ -142,7 +142,7 @@ w_int3 = iw.FloatSlider(value=0.8, min=0, max=1, description="int-ring3")
 w_int_back = iw.FloatSlider(value=0., min=0, max=1, description="intensity background")
 
 w_ori = iw.Dropdown(value="center", options=['mean', 'corner', 'center'], description="origin")
-w_mask = iw.Dropdown(value=None, options=[None, 'target_mask', 'frame_mask'], description="add mask")
+w_mask = iw.Dropdown(value=None, options=[None, 'target_mask', 'ring_mask'], description="add mask")
 
 w_tidx = iw.IntSlider(value=1, min=1, max=4, description="target idx")
 w_tint = iw.FloatSlider(value=0.5, min=0, max=1, description="target int")

--- a/stimupy/components/angulars.py
+++ b/stimupy/components/angulars.py
@@ -39,7 +39,7 @@ def mask_angle(
     Returns
     -------
     dict[str, Any]
-        dict with boolean mask (key: bool_mask) for pixels falling in given angle,
+        dict with boolean mask (key: "segment_mask") for pixels falling in given angle,
         and additional params
     """
     stim = mask_regions(
@@ -51,8 +51,7 @@ def mask_angle(
         ppd=ppd,
         origin=origin,
     )
-    stim["wedge_mask"] = stim["mask"]
-    del stim["mask"]
+    stim["segment_mask"] = stim.pop("mask")
     return stim
 
 
@@ -131,16 +130,19 @@ def wedge(
         origin=origin,
     )
 
-    # Remove everything but wedge, and add additional args
-    stim["img"] = np.where(mask["wedge_mask"], stim["img"], intensity_background)
-    stim["wedge_mask"] = stim["ring_mask"] * mask["wedge_mask"]
+    # Combine masks
+    stim["wedge_mask"] = stim.pop("ring_mask") * mask["segment_mask"]
     stim["wedge_mask"] = np.where(stim["wedge_mask"] != 0, 1, 0).astype(int)
+
+    # Draw image
+    stim["img"] = np.where(stim["wedge_mask"], intensity_wedge, intensity_background)
+
+    # Repackage
     stim["angle"] = angle
     stim["radius"] = radius
     stim["inner_radius"] = inner_radius
     stim["intensity_wedge"] = intensity_wedge
     stim["intensity_background"] = intensity_background
-    del stim["ring_mask"]
     return stim
 
 
@@ -175,7 +177,7 @@ def mask_segments(
     -------
     dict[str, Any]
         dict with the stimulus (key: "img"),
-        mask with integer index for each segment (key: "wedge_mask"),
+        mask with integer index for each segment (key: "segment_mask"),
         and additional keys containing stimulus parameters
     """
     stim = mask_regions(
@@ -187,8 +189,7 @@ def mask_segments(
         ppd=ppd,
         origin=origin,
     )
-    stim["wedge_mask"] = stim["mask"]
-    del stim["mask"]
+    stim["segment_mask"] = stim.pop("mask")
     return stim
 
 
@@ -230,7 +231,7 @@ def segments(
     -------
     dict[str, Any]
         dict with the stimulus (key: "img"),
-        mask with integer index for each segment (key: "wedge_mask"),
+        mask with integer index for each segment (key: "segment_mask"),
         and additional keys containing stimulus parameters
     """
     if angles is None:
@@ -251,7 +252,7 @@ def segments(
 
     # Draw image
     stim["img"] = draw_regions(
-        stim["wedge_mask"],
+        stim["segment_mask"],
         intensities=intensity_segments,
         intensity_background=intensity_background,
     )

--- a/stimupy/components/frames.py
+++ b/stimupy/components/frames.py
@@ -49,8 +49,8 @@ def mask_frames(
         ppd=ppd,
         origin=origin,
     )
-    stim["frame_mask"] = stim["mask"]
-    del stim["mask"]
+    stim["frame_mask"] = stim.pop("mask")
+
     return stim
 
 

--- a/stimupy/stimuli/delboeufs.py
+++ b/stimupy/stimuli/delboeufs.py
@@ -86,11 +86,10 @@ def delboeuf(
     inner["line_mask"] = outer["line_mask"]
     inner["outer_radius"] = outer_radius
     inner["target_radius"] = target_radius
-    inner["target_mask"] = inner["ring_mask"]
+    inner["target_mask"] = inner.pop("ring_mask")
     inner["outer_line_width"] = outer["line_width"]
     inner["intensity_outer_line"] = intensity_outer_line
     inner["intensity_target"] = intensity_target
-    del inner["ring_mask"]
     return inner
 
 

--- a/stimupy/stimuli/pinwheels.py
+++ b/stimupy/stimuli/pinwheels.py
@@ -104,14 +104,15 @@ def pinwheel(
 
     # Mask to circular aperture
     radius = min(stim["visual_size"]) / 2
-    circle_aperture = circle(
+    stim["circle_mask"] = circle(
         visual_size=visual_size,
         ppd=ppd,
         shape=shape,
         radius=radius,
         origin=origin,
     )["circle_mask"]
-    stim["img"] = np.where(circle_aperture, stim["img"], intensity_background)
+    stim["segment_mask"] = np.where(stim["circle_mask"], stim["segment_mask"], 0)
+    stim["img"] = np.where(stim["circle_mask"], stim["img"], intensity_background)
     stim["intensity_background"] = intensity_background
 
     # Target segment mask

--- a/stimupy/stimuli/waves.py
+++ b/stimupy/stimuli/waves.py
@@ -121,6 +121,9 @@ def sine_linear(
     stim["bar_width"] = stim.pop("phase_width")
     stim.pop("distance_metric")
 
+    # Rename mask
+    stim["bar_mask"] = stim["grating_mask"]
+
     # Add targets
     stim = place_targets(
         stim=stim,
@@ -226,6 +229,9 @@ def square_linear(
     stim["bar_width"] = stim.pop("phase_width")
     stim["intensity_bars"] = stim.pop("intensities")
     stim.pop("distance_metric")
+
+    # Rename mask
+    stim["bar_mask"] = stim["grating_mask"]
 
     # Add targets
     stim = place_targets(
@@ -335,6 +341,9 @@ def staircase_linear(
     stim["bar_width"] = stim.pop("phase_width")
     stim["intensity_bars"] = stim.pop("intensities")
     stim.pop("distance_metric")
+
+    # Rename mask
+    stim["bar_mask"] = stim["grating_mask"]
 
     # Add targets
     stim = place_targets(
@@ -460,6 +469,9 @@ def sine_radial(
     stim["clip"] = clip
     stim["intensity_background"] = intensity_background
 
+    # Rename mask
+    stim["ring_mask"] = stim["grating_mask"]
+
     # Add targets
     stim = place_targets(
         stim=stim,
@@ -583,6 +595,9 @@ def square_radial(
         stim["grating_mask"] = np.where(circle["ring_mask"], stim["grating_mask"], 0)
     stim["clip"] = clip
     stim["intensity_background"] = intensity_background
+
+    # Rename mask
+    stim["ring_mask"] = stim["grating_mask"]
 
     # Add targets
     stim = place_targets(
@@ -708,6 +723,9 @@ def staircase_radial(
         stim["grating_mask"] = np.where(circle["ring_mask"], stim["grating_mask"], 0)
     stim["clip"] = clip
     stim["intensity_background"] = intensity_background
+
+    # Rename mask
+    stim["ring_mask"] = stim["grating_mask"]
 
     # Add targets
     stim = place_targets(
@@ -840,6 +858,9 @@ def sine_rectilinear(
         stim["grating_mask"] = np.where(rect["rectangle_mask"], stim["grating_mask"], 0)
     stim["clip"] = clip
     stim["intensity_background"] = intensity_background
+
+    # Rename mask
+    stim["frame_mask"] = stim["grating_mask"]
 
     # Add targets
     stim = place_targets(
@@ -974,6 +995,9 @@ def square_rectilinear(
     stim["clip"] = clip
     stim["intensity_background"] = intensity_background
 
+    # Rename mask
+    stim["frame_mask"] = stim["grating_mask"]
+
     # Add targets
     stim = place_targets(
         stim=stim,
@@ -1107,6 +1131,9 @@ def staircase_rectilinear(
     stim["clip"] = clip
     stim["intensity_background"] = intensity_background
 
+    # Rename mask
+    stim["frame_mask"] = stim["grating_mask"]
+
     # Add targets
     stim = place_targets(
         stim=stim,
@@ -1210,6 +1237,9 @@ def sine_angular(
     stim["n_segments"] = stim.pop("n_phases")
     stim["segment_width"] = stim.pop("phase_width")
     stim.pop("distance_metric")
+
+    # Rename mask
+    stim["segment_mask"] = stim["grating_mask"]
 
     # Add targets
     stim = place_targets(
@@ -1317,6 +1347,9 @@ def square_angular(
     stim["intensity_segments"] = stim.pop("intensities")
     stim.pop("distance_metric")
 
+    # Rename mask
+    stim["segment_mask"] = stim["grating_mask"]
+
     # Add targets
     stim = place_targets(
         stim=stim,
@@ -1421,6 +1454,9 @@ def staircase_angular(
     stim["segment_width"] = stim.pop("phase_width")
     stim["intensity_segments"] = stim.pop("intensities")
     stim.pop("distance_metric")
+
+    # Rename mask
+    stim["segment_mask"] = stim["grating_mask"]
 
     # Add targets
     stim = place_targets(


### PR DESCRIPTION
Add a distance-specific mask (`bar_`, `ring_`, `frame_`, `segment_`). These are similarly named in the "generalized" versions of these stimuli (`frames`, `rings`, etc.).
This is just a reference to `grating_mask`, so that will remain consistent between all `wave`-like stimuli.

Closes #102
