### PR TITLE
SBCs

### DIFF
--- a/docs/reference/demos/stimuli/sbcs.md
+++ b/docs/reference/demos/stimuli/sbcs.md
@@ -179,6 +179,173 @@ out = iw.interactive_output(
 display(ui, out)
 ```
 
+## Square
+{py:func}`stimupy.stimuli.sbcs.square`
+
+```{code-cell} ipython3
+import ipywidgets as iw
+from stimupy.utils import plot_stim
+from stimupy.stimuli.sbcs import square
+
+# Define widgets
+w_height = iw.IntSlider(value=10, min=1, max=20, description="height [deg]")
+w_width = iw.IntSlider(value=10, min=1, max=20, description="width [deg]")
+w_ppd = iw.IntSlider(value=20, min=1, max=40, description="ppd")
+
+w_radius_target = iw.FloatSlider(value=1, min=0, max=2, description="target radius [deg]")
+w_radius_surround = iw.FloatSlider(value=2, min=1, max=3, description="surround radius [deg]")
+
+w_int_surround = iw.FloatSlider(value=1, min=0, max=1, description="int surround")
+w_int_back = iw.FloatSlider(value=0.5, min=0, max=1, description="intensity background")
+
+w_ori = iw.Dropdown(value="center", options=['mean', 'corner', 'center'], description="origin")
+w_rot = iw.FloatSlider(value=0, min=0, max=360, description="rotation [deg]")
+w_mask = iw.Dropdown(value=None, options=[None, 'target_mask', 'frame_mask'], description="add mask")
+
+w_tint = iw.FloatSlider(value=0.5, min=0, max=1, description="target int")
+
+# Layout
+b_im_size = iw.HBox([w_height, w_width, w_ppd])
+b_geometry = iw.HBox([w_radius_target, w_radius_surround])
+b_intensities = iw.HBox([w_int_surround, w_int_back])
+b_target = iw.HBox([w_tint])
+b_add = iw.HBox([w_ori, w_rot, w_mask])
+ui = iw.VBox([b_im_size, b_geometry, b_intensities, b_target, b_add])
+
+# Function for showing stim
+def show_square(
+    height=None,
+    width=None,
+    ppd=None,
+    target_radius=None,
+    surround_radius=None,
+    intensity_surround=None,
+    intensity_background=None,
+    origin=None,
+    add_mask=False,
+    intensity_target=None,
+    rotation=0.0,
+):
+    try:
+        stim = square(
+            visual_size=(height, width),
+            ppd=ppd,
+            target_radius=target_radius,
+            surround_radius=surround_radius,
+            intensity_surround=intensity_surround,
+            intensity_background=intensity_background,
+            origin=origin,
+            intensity_target=intensity_target,
+            rotation=rotation,
+        )
+        plot_stim(stim, mask=add_mask)
+    except Exception as e:
+        raise ValueError(f"Invalid parameter combination: {e}") from None
+
+# Set interactivity
+out = iw.interactive_output(
+    show_square,
+    {
+        "height": w_height,
+        "width": w_width,
+        "ppd": w_ppd,
+        "target_radius": w_radius_target,
+        "surround_radius": w_radius_surround,
+        "intensity_surround": w_int_surround,
+        "intensity_background": w_int_back,
+        "origin": w_ori,
+        "add_mask": w_mask,
+        "intensity_target": w_tint,
+        "rotation": w_rot,
+    },
+)
+
+# Show
+display(ui, out)
+```
+
+
+## Circular
+{py:func}`stimupy.stimuli.sbcs.circular`
+
+```{code-cell} ipython3
+import ipywidgets as iw
+from stimupy.utils import plot_stim
+from stimupy.stimuli.sbcs import circular
+
+# Define widgets
+w_height = iw.IntSlider(value=10, min=1, max=20, description="height [deg]")
+w_width = iw.IntSlider(value=10, min=1, max=20, description="width [deg]")
+w_ppd = iw.IntSlider(value=20, min=1, max=40, description="ppd")
+
+w_radius_target = iw.FloatSlider(value=1, min=0, max=2, description="target radius [deg]")
+w_radius_surround = iw.FloatSlider(value=2, min=1, max=3, description="surround radius [deg]")
+
+w_int_surround = iw.FloatSlider(value=1, min=0, max=1, description="int surround")
+w_int_back = iw.FloatSlider(value=0.5, min=0, max=1, description="intensity background")
+
+w_ori = iw.Dropdown(value="center", options=['mean', 'corner', 'center'], description="origin")
+w_mask = iw.Dropdown(value=None, options=[None, 'target_mask', 'ring_mask'], description="add mask")
+
+w_tint = iw.FloatSlider(value=0.5, min=0, max=1, description="target int")
+
+# Layout
+b_im_size = iw.HBox([w_height, w_width, w_ppd])
+b_geometry = iw.HBox([w_radius_target, w_radius_surround])
+b_intensities = iw.HBox([w_int_surround, w_int_back])
+b_target = iw.HBox([w_tint])
+b_add = iw.HBox([w_ori, w_mask])
+ui = iw.VBox([b_im_size, b_geometry, b_intensities, b_target, b_add])
+
+# Function for showing stim
+def show_circular(
+    height=None,
+    width=None,
+    ppd=None,
+    target_radius=None,
+    surround_radius=None,
+    intensity_surround=None,
+    intensity_background=None,
+    origin=None,
+    add_mask=False,
+    intensity_target=None,
+):
+    try:
+        stim = circular(
+            visual_size=(height, width),
+            ppd=ppd,
+            target_radius=target_radius,
+            surround_radius=surround_radius,
+            intensity_surround=intensity_surround,
+            intensity_background=intensity_background,
+            origin=origin,
+            intensity_target=intensity_target,
+        )
+        plot_stim(stim, mask=add_mask)
+    except Exception as e:
+        raise ValueError(f"Invalid parameter combination: {e}") from None
+
+# Set interactivity
+out = iw.interactive_output(
+    show_circular,
+    {
+        "height": w_height,
+        "width": w_width,
+        "ppd": w_ppd,
+        "target_radius": w_radius_target,
+        "surround_radius": w_radius_surround,
+        "intensity_surround": w_int_surround,
+        "intensity_background": w_int_back,
+        "origin": w_ori,
+        "add_mask": w_mask,
+        "intensity_target": w_tint,
+    },
+)
+
+# Show
+display(ui, out)
+```
+
 ## Two sided
 {py:func}`stimupy.stimuli.sbcs.basic_two_sided`
 

--- a/docs/reference/demos/stimuli/sbcs.md
+++ b/docs/reference/demos/stimuli/sbcs.md
@@ -73,6 +73,7 @@ def show_generalized(
     intensity_background=None,
     intensity_target=None,
     add_mask=False,
+    rotation=0.0,
 ):
     try:
         stim = generalized(
@@ -82,6 +83,7 @@ def show_generalized(
             target_position=(target_y,target_x),
             intensity_background=intensity_background,
             intensity_target=intensity_target,
+            rotation=rotation,
         )
         plot_stim(stim, mask=add_mask)
     except Exception as e:
@@ -101,6 +103,7 @@ out = iw.interactive_output(
         "intensity_background": w_int_back,
         "intensity_target": w_tint,
         "add_mask": w_mask,
+        "rotation": w_rot,
     },
 )
 

--- a/docs/reference/demos/stimuli/sbcs.md
+++ b/docs/reference/demos/stimuli/sbcs.md
@@ -346,7 +346,7 @@ out = iw.interactive_output(
 display(ui, out)
 ```
 
-## Two sided
+## Basic, Two sided
 {py:func}`stimupy.stimuli.sbcs.basic_two_sided`
 
 ```{code-cell} ipython3
@@ -423,6 +423,193 @@ out = iw.interactive_output(
 # Show
 display(ui, out)
 ```
+
+## Square, Two sided
+{py:func}`stimupy.stimuli.sbcs.square_two_sided`
+
+```{code-cell} ipython3
+import ipywidgets as iw
+from stimupy.utils import plot_stim
+from stimupy.stimuli.sbcs import square_two_sided
+
+# Define widgets
+w_height = iw.IntSlider(value=10, min=1, max=20, description="height [deg]")
+w_width = iw.IntSlider(value=10, min=1, max=20, description="width [deg]")
+w_ppd = iw.IntSlider(value=20, min=1, max=40, description="ppd")
+
+w_t_radius_l = iw.IntSlider(value=1, min=1, max=6, description="target radius left [deg]")
+w_t_radius_r = iw.IntSlider(value=1, min=1, max=6, description="target radius right [deg]")
+w_radius_surround_l = iw.IntSlider(value=2, min=1, max=6, description="surround radius left [deg]")
+w_radius_surround_r = iw.IntSlider(value=2, min=1, max=6, description="surround radius right [deg]")
+
+w_tint_l = iw.FloatSlider(value=0.5, min=0, max=1, description="intensity target left")
+w_tint_r = iw.FloatSlider(value=0.5, min=0, max=1, description="intensity target right")
+w_int_surround_l = iw.FloatSlider(value=0., min=0, max=1, description="intensity left surround")
+w_int_surround_r = iw.FloatSlider(value=1., min=0, max=1, description="intensity right surround")
+w_int_background = iw.FloatSlider(value=.5, min=0, max=1, description="intenisty background")
+
+w_rot_l = iw.FloatSlider(value=0, min=0, max=360, description="rotation left [deg]")
+w_rot_r = iw.FloatSlider(value=0, min=0, max=360, description="rotation right [deg]")
+w_mask = iw.ToggleButton(value=False, disabled=False, description="add mask")
+
+
+# Layout
+b_im_size = iw.HBox([w_height, w_width, w_ppd])
+b_t_size = iw.HBox([w_t_radius_l, w_t_radius_l])
+b_s_size = iw.HBox([w_radius_surround_l, w_radius_surround_r])
+b_intensities = iw.HBox([w_tint_l, w_tint_r, w_int_back_l, w_int_back_r])
+b_add = iw.HBox([w_rot_l, w_rot_r, w_mask])
+ui = iw.VBox([b_im_size, b_t_size, b_s_size, b_intensities, b_add])
+
+# Function for showing stim
+def show_square_two_sided(
+    height=None,
+    width=None,
+    ppd=None,
+    target_radius_l=None,
+    target_radius_r=None,
+    surround_radius_l=None,
+    surround_radius_r=None,
+    intensity_surround_l=None,
+    intensity_surround_r=None,
+    intensity_target_l=None,
+    intensity_target_r=None,
+    intensity_background=None,
+    add_mask=False,
+    rotation_l=None,
+    rotation_r=None,
+):
+    try:
+        stim = square_two_sided(
+            visual_size=(height, width),
+            ppd=ppd,
+            target_radius=(target_radius_l,target_radius_r),
+            surround_radius=(surround_radius_l, surround_radius_r),
+            intensity_surround=(intensity_surround_l, intensity_surround_r),
+            intensity_target=(intensity_target_l, intensity_target_r),
+            intensity_background=intensity_background,
+            rotation=(rotation_l, rotation_r),
+        )
+        plot_stim(stim, mask=add_mask)
+    except Exception as e:
+        raise ValueError(f"Invalid parameter combination: {e}") from None
+
+# Set interactivity
+out = iw.interactive_output(
+    show_square_two_sided,
+    {
+        "height": w_height,
+        "width": w_width,
+        "ppd": w_ppd,
+        "target_radius_l": w_t_radius_l,
+        "target_radius_r": w_t_radius_r,
+        "surround_radius_l": w_radius_surround_l,
+        "surround_radius_r": w_radius_surround_r,
+        "intensity_surround_l": w_int_surround_l,
+        "intensity_surround_r": w_int_surround_r,
+        "intensity_target_l": w_tint_l,
+        "intensity_target_r": w_tint_r,
+        "intensity_background": w_int_background,
+        "rotation_l": w_rot_l,
+        "rotation_r": w_rot_r,
+        "add_mask": w_mask,
+    },
+)
+
+# Show
+display(ui, out)
+```
+
+## Circular, Two sided
+{py:func}`stimupy.stimuli.sbcs.circular_two_sided`
+
+```{code-cell} ipython3
+import ipywidgets as iw
+from stimupy.utils import plot_stim
+from stimupy.stimuli.sbcs import circular_two_sided
+
+# Define widgets
+w_height = iw.IntSlider(value=10, min=1, max=20, description="height [deg]")
+w_width = iw.IntSlider(value=10, min=1, max=20, description="width [deg]")
+w_ppd = iw.IntSlider(value=20, min=1, max=40, description="ppd")
+
+w_t_radius_l = iw.IntSlider(value=1, min=1, max=6, description="target radius left [deg]")
+w_t_radius_r = iw.IntSlider(value=1, min=1, max=6, description="target radius right [deg]")
+w_radius_surround_l = iw.IntSlider(value=2, min=1, max=6, description="surround radius left [deg]")
+w_radius_surround_r = iw.IntSlider(value=2, min=1, max=6, description="surround radius right [deg]")
+
+w_tint_l = iw.FloatSlider(value=0.5, min=0, max=1, description="intensity target left")
+w_tint_r = iw.FloatSlider(value=0.5, min=0, max=1, description="intensity target right")
+w_int_surround_l = iw.FloatSlider(value=0., min=0, max=1, description="intensity left surround")
+w_int_surround_r = iw.FloatSlider(value=1., min=0, max=1, description="intensity right surround")
+w_int_background = iw.FloatSlider(value=.5, min=0, max=1, description="intenisty background")
+
+
+w_mask = iw.ToggleButton(value=False, disabled=False, description="add mask")
+
+
+# Layout
+b_im_size = iw.HBox([w_height, w_width, w_ppd])
+b_t_size = iw.HBox([w_t_radius_l, w_t_radius_l])
+b_s_size = iw.HBox([w_radius_surround_l, w_radius_surround_r])
+b_intensities = iw.HBox([w_tint_l, w_tint_r, w_int_back_l, w_int_back_r])
+b_add = iw.HBox([w_mask])
+ui = iw.VBox([b_im_size, b_t_size, b_s_size, b_intensities, b_add])
+
+# Function for showing stim
+def show_circular_two_sided(
+    height=None,
+    width=None,
+    ppd=None,
+    target_radius_l=None,
+    target_radius_r=None,
+    surround_radius_l=None,
+    surround_radius_r=None,
+    intensity_surround_l=None,
+    intensity_surround_r=None,
+    intensity_target_l=None,
+    intensity_target_r=None,
+    intensity_background=None,
+    add_mask=False,
+):
+    try:
+        stim = circular_two_sided(
+            visual_size=(height, width),
+            ppd=ppd,
+            target_radius=(target_radius_l,target_radius_r),
+            surround_radius=(surround_radius_l, surround_radius_r),
+            intensity_surround=(intensity_surround_l, intensity_surround_r),
+            intensity_target=(intensity_target_l, intensity_target_r),
+            intensity_background=intensity_background,
+        )
+        plot_stim(stim, mask=add_mask)
+    except Exception as e:
+        raise ValueError(f"Invalid parameter combination: {e}") from None
+
+# Set interactivity
+out = iw.interactive_output(
+    show_circular_two_sided,
+    {
+        "height": w_height,
+        "width": w_width,
+        "ppd": w_ppd,
+        "target_radius_l": w_t_radius_l,
+        "target_radius_r": w_t_radius_r,
+        "surround_radius_l": w_radius_surround_l,
+        "surround_radius_r": w_radius_surround_r,
+        "intensity_surround_l": w_int_surround_l,
+        "intensity_surround_r": w_int_surround_r,
+        "intensity_target_l": w_tint_l,
+        "intensity_target_r": w_tint_r,
+        "intensity_background": w_int_background,
+        "add_mask": w_mask,
+    },
+)
+
+# Show
+display(ui, out)
+```
+
 
 ## With dots
 {py:func}`stimupy.stimuli.sbcs.with_dots`

--- a/docs/reference/demos/stimuli/sbcs.md
+++ b/docs/reference/demos/stimuli/sbcs.md
@@ -427,6 +427,112 @@ out = iw.interactive_output(
 display(ui, out)
 ```
 
+## Generalized, Two sided
+{py:func}`stimupy.stimuli.sbcs.generalized_two_sided`
+
+```{code-cell} ipython3
+import ipywidgets as iw
+from stimupy.utils import plot_stim
+from stimupy.stimuli.sbcs import generalized_two_sided
+
+# Define widgets
+w_height = iw.IntSlider(value=10, min=1, max=20, description="height [deg]")
+w_width = iw.IntSlider(value=20, min=1, max=20, description="width [deg]")
+w_ppd = iw.IntSlider(value=20, min=1, max=40, description="ppd")
+
+w_t_height_l = iw.IntSlider(value=3, min=1, max=6, description="target height left [deg]")
+w_t_width_l = iw.IntSlider(value=3, min=1, max=6, description="target width right [deg]")
+w_t_height_r = iw.IntSlider(value=3, min=1, max=6, description="target height left [deg]")
+w_t_width_r = iw.IntSlider(value=3, min=1, max=6, description="target width right [deg]")
+
+w_t_y_l = iw.FloatSlider(value=5.0, min=0.0, max=20, description="y left target [deg]")
+w_t_x_l = iw.FloatSlider(value=5.0, min=0.0, max=20, description="x left target [deg]") 
+w_t_y_r = iw.FloatSlider(value=3.0, min=0.0, max=20, description="y right target [deg]")
+w_t_x_r = iw.FloatSlider(value=3.0, min=0.0, max=20, description="x right target [deg]")
+
+w_tint_l = iw.FloatSlider(value=0.5, min=0, max=1, description="intensity target left")
+w_tint_r = iw.FloatSlider(value=0.5, min=0, max=1, description="intensity target right")
+w_int_back_l = iw.FloatSlider(value=0., min=0, max=1, description="intensity left background")
+w_int_back_r = iw.FloatSlider(value=1., min=0, max=1, description="intensity right background")
+
+
+w_mask = iw.ToggleButton(value=False, disabled=False, description="add mask")
+
+
+# Layout
+b_im_size = iw.HBox([w_height, w_width, w_ppd])
+b_t_size_l = iw.HBox([w_t_height_l, w_t_width_l])
+b_t_size_r = iw.HBox([w_t_height_r, w_t_width_r])
+b_t_pos_l = iw.HBox([w_t_y_l, w_t_x_l])
+b_t_pos_r = iw.HBox([w_t_y_r, w_t_x_r])
+b_intensities_l = iw.HBox([w_tint_l, w_int_back_l])
+b_intensities_r = iw.HBox([w_tint_r, w_int_back_r])
+
+b_left = iw.VBox([b_t_size_l, b_t_pos_l, b_intensities_l])
+b_right = iw.VBox([b_t_size_r, b_t_pos_r, b_intensities_r])
+
+b_add = iw.HBox([w_mask])
+ui = iw.VBox([b_im_size, b_left, b_right, b_add])
+
+# Function for showing stim
+def show_gen_two_sided(
+    height=None,
+    width=None,
+    ppd=None,
+    target_height_l=None,
+    target_width_l=None,
+    target_height_r=None,
+    target_width_r=None,
+    target_pos_x_l=None,
+    target_pos_y_l=None,
+    target_pos_x_r=None,
+    target_pos_y_r=None,
+    intensity_background_l=None,
+    intensity_background_r=None,
+    intensity_target_l=None,
+    intensity_target_r=None,
+    add_mask=False,
+):
+    try:
+        stim = generalized_two_sided(
+            visual_size=(height, width),
+            ppd=ppd,
+            target_size=((target_height_l,target_width_l),(target_height_r,target_width_r)),
+            target_position=((target_pos_y_l, target_pos_x_l), (target_pos_y_r, target_pos_x_r)),
+            intensity_background=(intensity_background_l, intensity_background_r),
+            intensity_target=(intensity_target_l, intensity_target_r),
+        )
+        plot_stim(stim, mask=add_mask)
+    except Exception as e:
+        raise ValueError(f"Invalid parameter combination: {e}") from None
+
+# Set interactivity
+out = iw.interactive_output(
+    show_gen_two_sided,
+    {
+        "height": w_height,
+        "width": w_width,
+        "ppd": w_ppd,
+        "target_height_l": w_t_height_l,
+        "target_width_l": w_t_width_l,
+        "target_height_r": w_t_height_r,
+        "target_width_r": w_t_width_r,
+        "target_pos_x_l": w_t_x_l,
+        "target_pos_y_l": w_t_y_l,
+        "target_pos_x_r": w_t_x_r,
+        "target_pos_y_r": w_t_y_r,
+        "intensity_background_l": w_int_back_l,
+        "intensity_background_r": w_int_back_r,
+        "intensity_target_l": w_tint_l,
+        "intensity_target_r": w_tint_r,
+        "add_mask": w_mask,
+    },
+)
+
+# Show
+display(ui, out)
+```
+
 ## Square, Two sided
 {py:func}`stimupy.stimuli.sbcs.square_two_sided`
 

--- a/stimupy/components/frames.py
+++ b/stimupy/components/frames.py
@@ -78,13 +78,13 @@ def frames(
         radii of each frame, in degrees visual angle
     rotation : float, optional
         rotation (in degrees), counterclockwise, by default 0.0 (horizonal)
-    intensity_frames : Sequence[float, ...]
+    intensity_frames : Sequence[float, ...], optional
         intensity value for each frame, by default (1.0, 0.0).
         Can specify as many intensities as number of frame_widths;
         If fewer intensities are passed than frame_widhts, cycles through intensities
     intensity_background : float, optional
         intensity value of background, by default 0.5
-    origin : "corner", "mean" or "center"
+    origin : "corner", "mean" or "center", optional
         if "corner": set origin to upper left corner
         if "mean": set origin to hypothetical image center (default)
         if "center": set origin to real center (closest existing value to mean)

--- a/stimupy/components/radials.py
+++ b/stimupy/components/radials.py
@@ -92,12 +92,12 @@ def rings(
         shape [height, width] of image, in pixels
     radii : Sequence[Number]
         outer radii of rings (& disc) in degree visual angle
-    intensity_rings : Sequence[Number, ...]
-        intensity value for each ring, from inside to out.
+    intensity_rings : Sequence[Number, ...], optional
+        intensity value for each ring, from inside to out, by default (0.0, 1.0)
         If fewer intensities are passed than number of radii, cycles through intensities
-    intensity_background : float (optional)
+    intensity_background : float, optional
         value of background, by default 0.5
-    origin : "corner", "mean" or "center"
+    origin : "corner", "mean" or "center", optional
         if "corner": set origin to upper left corner
         if "mean": set origin to hypothetical image center (default)
         if "center": set origin to real center (closest existing value to mean)
@@ -175,11 +175,11 @@ def disc(
         shape [height, width] of image, in pixels
     radius : Number
         outer radius of disc in degree visual angle
-    intensity_disc : Number
+    intensity_disc : Number, optional
         intensity value of disc, by default 1.0
-    intensity_background : float (optional)
+    intensity_background : float, optional
         intensity value of background, by default 0.0
-    origin : "corner", "mean" or "center"
+    origin : "corner", "mean" or "center", optional
         if "corner": set origin to upper left corner
         if "mean": set origin to hypothetical image center (default)
         if "center": set origin to real center (closest existing value to mean)
@@ -238,11 +238,11 @@ def ring(
         shape [height, width] of image, in pixels
     radii : Sequence[Number, Number]
         inner and outer radius of ring in degree visual angle
-    intensity_ring : Number
+    intensity_ring : Number, optional
         intensity value of ring, by default 1.0
-    intensity_background : float (optional)
+    intensity_background : float, optional
         intensity value of background, by default 0.0
-    origin : "corner", "mean" or "center"
+    origin : "corner", "mean" or "center", optional
         if "corner": set origin to upper left corner
         if "mean": set origin to hypothetical image center (default)
         if "center": set origin to real center (closest existing value to mean)

--- a/stimupy/components/radials.py
+++ b/stimupy/components/radials.py
@@ -127,7 +127,7 @@ def rings(
     # Resolve radii
     if radii is None:
         raise ValueError("rings() missing argument 'radii' which is not 'None'")
-    if (isinstance(radii, collections.abc.Sequence) or isinstance(radii, np.ndarray)):
+    if isinstance(radii, collections.abc.Sequence) or isinstance(radii, np.ndarray):
         if np.diff(radii).min() < 0:
             raise ValueError("radii need to monotonically increase")
     else:

--- a/stimupy/components/radials.py
+++ b/stimupy/components/radials.py
@@ -1,3 +1,4 @@
+import collections
 import itertools
 
 import numpy as np
@@ -199,26 +200,26 @@ def disc(
     if radius is None:
         raise ValueError("disc() missing argument 'radius' which is not 'None'")
 
-    radius = np.array(radius)
-    intensity = np.array(intensity_disc)
+    if isinstance(radius, np.ndarray):
+        try:
+            radius = float(radius)
+        except TypeError as e:
+            raise ValueError("Can only pass 1 radius") from e
+    elif isinstance(radius, collections.abc.Sequence):
+        if len(radius) != 1:
+            raise ValueError("Can only pass 1 radius")
 
-    if radius.size != 1:
-        raise ValueError("Can only pass 1 radius")
-    if intensity.size != 1:
-        raise ValueError("Can only pass 1 intensity")
-
-    stim = ring(
-        radii=np.insert(radius, 0, 0),
-        intensity_ring=intensity,
+    stim = rings(
+        radii=radius,
+        intensity_rings=intensity_disc,
         visual_size=visual_size,
         ppd=ppd,
         intensity_background=intensity_background,
         shape=shape,
         origin=origin,
     )
-    stim["radius"] = radius
-    stim["intensity_disc"] = intensity_disc
-    del stim["radii"], stim["intensity_rings"]
+    stim["radius"] = stim.pop("radii")
+    stim["intensity_disc"] = stim.pop("intensity_rings")
     return stim
 
 

--- a/stimupy/papers/RHS2007.py
+++ b/stimupy/papers/RHS2007.py
@@ -955,23 +955,13 @@ def sbc_large(ppd=PPD, pad=True):
         Vision Research, 39, 4361-4377.
     """
 
-    params = {
-        "ppd": ppd,
-        "target_size": 3.0,
-        "intensity_target": v2,
-    }
-
-    stim1 = stimupy.sbcs.basic(
-        visual_size=(13.0, 15.5),
-        intensity_background=0.0,
-        **params,
+    stim = stimupy.sbcs.basic_two_sided(
+        visual_size=(13.0, 31.0),
+        ppd=ppd,
+        target_size=3.0,
+        intensity_target=v2,
+        intensity_background=(0.0, 1.0),
     )
-    stim2 = stimupy.sbcs.basic(
-        visual_size=(13.0, 15.5),
-        intensity_background=1.0,
-        **params,
-    )
-    stim = stack_dicts(stim1, stim2)
 
     if pad:
         stim = pad_dict_to_visual_size(stim, VISEXTENT, ppd, pad_value=v2)
@@ -980,13 +970,13 @@ def sbc_large(ppd=PPD, pad=True):
         "effect_strength": 11.35,
     }
 
-    params.update(
+    stim.update(
         visual_size=np.array(stim["img"].shape) / ppd,
         shape=stim["img"].shape,
         intensity_range=(v1, v3),
         experimental_data=experimental_data,
     )
-    return {**stim, **params}
+    return stim
 
 
 def sbc_small(ppd=PPD, pad=True):
@@ -1015,23 +1005,13 @@ def sbc_small(ppd=PPD, pad=True):
         Vision Research, 39, 4361-4377.
     """
 
-    params = {
-        "ppd": ppd,
-        "target_size": 1.0,
-        "intensity_target": v2,
-    }
-
-    stim1 = stimupy.sbcs.basic(
-        visual_size=(13.0, 15.5),
-        intensity_background=0.0,
-        **params,
+    stim = stimupy.sbcs.basic_two_sided(
+        visual_size=(13.0, 31.0),
+        ppd=ppd,
+        target_size=1.0,
+        intensity_background=(0.0, 1.0),
+        intensity_target=v2,
     )
-    stim2 = stimupy.sbcs.basic(
-        visual_size=(13.0, 15.5),
-        intensity_background=1.0,
-        **params,
-    )
-    stim = stack_dicts(stim1, stim2)
 
     if pad:
         stim = pad_dict_to_visual_size(stim, VISEXTENT, ppd, pad_value=v2)
@@ -1040,13 +1020,13 @@ def sbc_small(ppd=PPD, pad=True):
         "effect_strength": 19.78,
     }
 
-    params.update(
+    stim.update(
         visual_size=np.array(stim["img"].shape) / ppd,
         shape=stim["img"].shape,
         intensity_range=(v1, v3),
         experimental_data=experimental_data,
     )
-    return {**stim, **params}
+    return stim
 
 
 def todorovic_equal(ppd=PPD, pad=True):

--- a/stimupy/papers/domijan2015.py
+++ b/stimupy/papers/domijan2015.py
@@ -564,30 +564,17 @@ def simultaneous_brightness_contrast(
     shape, visual_size, ppd, visual_resize = resolve(
         shape, visual_size, ppd, VSIZES["simultaneous_brightness_contrast"]
     )
-    ppd = ppd[0]
 
-    params = {
-        "visual_size": visual_size[0],
-        "ppd": ppd,
-        "target_size": (2.1 * visual_resize, 2.1 * visual_resize),
-        "target_position": (3.8 * visual_resize, 3.8 * visual_resize),
-    }
-
-    stim1 = stimupy.sbcs.generalized(
-        **params,
-        intensity_background=v3,
-        intensity_target=v2,
-    )
-    stim2 = stimupy.sbcs.generalized(
-        **params,
-        intensity_background=v1,
+    stim = stimupy.sbcs.generalized_two_sided(
+        visual_size=visual_size,
+        ppd=ppd,
+        target_size=(2.1 * visual_resize, 2.1 * visual_resize),
+        target_position=(3.8 * visual_resize, 3.8 * visual_resize),
+        intensity_background=(v3, v1),
         intensity_target=v2,
     )
 
-    # Stacking
-    stim = stack_dicts(stim1, stim2)
-
-    params.update(
+    stim.update(
         original_shape=SHAPES["simultaneous_brightness_contrast"],
         original_ppd=PPD,
         original_visual_size=VSIZES["simultaneous_brightness_contrast"],
@@ -596,7 +583,7 @@ def simultaneous_brightness_contrast(
         visual_size=resolution.visual_size_from_shape_ppd(stim["img"].shape, ppd),
         shape=stim["img"].shape,
     )
-    return {**stim, **params}
+    return stim
 
 
 def white(visual_size=VSIZES["white"], ppd=PPD, pad=PAD, shape=SHAPES["white"]):

--- a/stimupy/stimuli/sbcs.py
+++ b/stimupy/stimuli/sbcs.py
@@ -522,6 +522,18 @@ def dotted(
     return stim
 
 
+generalized_two_sided = make_two_sided(
+    generalized,
+    two_sided_params=(
+        "target_size",
+        "target_position",
+        "rotation",
+        "intensity_target",
+        "intensity_background",
+    ),
+)
+
+
 basic_two_sided = make_two_sided(
     basic, two_sided_params=("target_size", "intensity_target", "intensity_background")
 )

--- a/stimupy/stimuli/sbcs.py
+++ b/stimupy/stimuli/sbcs.py
@@ -1,11 +1,14 @@
 import numpy as np
 
 from stimupy.components.shapes import disc, rectangle
+from stimupy.stimuli import bullseyes
 from stimupy.utils import make_two_sided, pad_by_visual_size, pad_to_shape, resolution
 
 __all__ = [
     "generalized",
     "basic",
+    "square",
+    "circular",
     "basic_two_sided",
     "with_dots",
     "with_dots_two_sided",
@@ -129,6 +132,126 @@ def basic(
         target_position=None,
         intensity_background=intensity_background,
         intensity_target=intensity_target,
+    )
+    return stim
+
+
+def square(
+    target_radius,
+    visual_size=None,
+    ppd=None,
+    shape=None,
+    surround_radius=None,
+    rotation=0.0,
+    intensity_surround=0.0,
+    intensity_background=0.5,
+    intensity_target=0.5,
+    origin="mean",
+):
+    """Simultaneous contrast stimulus with square target and surround field
+
+    Parameters
+    ----------
+    visual_size : Sequence[Number, Number], Number, or None (default)
+        visual size [height, width] of image, in degrees
+    ppd : Sequence[Number, Number], Number, or None (default)
+        pixels per degree [vertical, horizontal]
+    shape : Sequence[Number, Number], Number, or None (default)
+        shape [height, width] of image, in pixels
+    target_radius : float
+        radius of target, in degrees visual angle
+    surround_radius : float
+        radius of surround context field, in degrees visual angle
+    rotation : float, optional
+        rotation (in degrees), counterclockwise, by default 0.0 (horizonal)
+    intensity_surrond : float, optional
+        intensity of surround context field, by default 0.0
+    intensity_background : float, optional
+        intensity value of background, by default 0.5
+    intensity_target : float, or Sequence[float, ...], optional
+        intensity value for each target, by default 0.5.
+    origin : "corner", "mean" or "center"
+        if "corner": set origin to upper left corner
+        if "mean": set origin to hypothetical image center (default)
+        if "center": set origin to real center (closest existing value to mean)
+
+    Returns
+    -------
+    dict[str, Any]
+        dict with the stimulus (key: "img"),
+        mask with integer index for each frame (key: "target_mask"),
+        and additional keys containing stimulus parameters
+    """
+    stim = bullseyes.rectangular_generalized(
+        radii=(target_radius, surround_radius),
+        visual_size=visual_size,
+        ppd=ppd,
+        shape=shape,
+        rotation=rotation,
+        intensity_frames=(0.0, intensity_surround),
+        intensity_background=intensity_background,
+        intensity_target=intensity_target,
+        origin=origin,
+    )
+    return stim
+
+
+def circular(
+    target_radius,
+    visual_size=None,
+    ppd=None,
+    shape=None,
+    surround_radius=None,
+    intensity_surround=0.0,
+    intensity_background=0.5,
+    intensity_target=0.5,
+    origin="mean",
+):
+    """Simultaneous contrast stimulus with circular target and surround field
+
+    Parameters
+    ----------
+    visual_size : Sequence[Number, Number], Number, or None (default)
+        visual size [height, width] of image, in degrees
+    ppd : Sequence[Number, Number], Number, or None (default)
+        pixels per degree [vertical, horizontal]
+    shape : Sequence[Number, Number], Number, or None (default)
+        shape [height, width] of image, in pixels
+    target_radius : float
+        radius of target, in degrees visual angle
+    surround_radius : float
+        radius of surround context field, in degrees visual angle
+    rotation : float, optional
+        rotation (in degrees), counterclockwise, by default 0.0 (horizonal)
+    intensity_surrond : float, optional
+        intensity of surround context field, by default 0.0
+    intensity_background : float (optional)
+        intensity value of background, by default 0.5
+    intensity_target : float, or Sequence[float, ...], optional
+        intensity value for each target, by default 0.5.
+        Can specify as many intensities as number of target_indices;
+        If fewer intensities are passed than target_indices, cycles through intensities
+    origin : "corner", "mean" or "center"
+        if "corner": set origin to upper left corner
+        if "mean": set origin to hypothetical image center (default)
+        if "center": set origin to real center (closest existing value to mean)
+
+    Returns
+    -------
+    dict[str, Any]
+        dict with the stimulus (key: "img"),
+        mask with integer index for each frame (key: "target_mask"),
+        and additional keys containing stimulus parameters
+    """
+    stim = bullseyes.circular_generalized(
+        radii=(target_radius, surround_radius),
+        visual_size=visual_size,
+        ppd=ppd,
+        shape=shape,
+        intensity_rings=(0.0, intensity_surround),
+        intensity_background=intensity_background,
+        intensity_target=intensity_target,
+        origin=origin,
     )
     return stim
 
@@ -436,6 +559,9 @@ def overview(**kwargs):
     stimuli = {
         "sbc_generalized": generalized(**default_params, visual_size=10, target_size=(3, 4), target_position=(1, 2)),
         "sbc_basic": basic(**default_params, visual_size=10, target_size=3),
+        "sbc_square": square(**default_params, visual_size=10, target_radius=1, surround_radius=2),
+        "sbc_circular": circular(**default_params, visual_size=10, target_radius=1, surround_radius=2),
+
         "sbc_2sided": basic_two_sided(**default_params, visual_size=10, target_size=2, intensity_background=(0.0, 1.0)),
         "sbc_with_dots": with_dots(**default_params, **dot_params),
         "sbc_with_dots_2sided": with_dots_two_sided(**default_params, **dot_params, intensity_background=(0.0, 1.0), intensity_dots=(1.0, 0.0)),

--- a/stimupy/stimuli/sbcs.py
+++ b/stimupy/stimuli/sbcs.py
@@ -9,10 +9,12 @@ __all__ = [
     "basic",
     "square",
     "circular",
-    "basic_two_sided",
     "with_dots",
-    "with_dots_two_sided",
     "dotted",
+    "basic_two_sided",
+    "square_two_sided",
+    "circular_two_sided",
+    "with_dots_two_sided",
     "dotted_two_sided",
 ]
 
@@ -256,11 +258,6 @@ def circular(
     return stim
 
 
-basic_two_sided = make_two_sided(
-    basic, two_sided_params=("target_size", "intensity_target", "intensity_background")
-)
-
-
 def with_dots(
     visual_size=None,
     ppd=None,
@@ -391,11 +388,6 @@ def with_dots(
     }
 
     return stim
-
-
-with_dots_two_sided = make_two_sided(
-    with_dots, two_sided_params=("intensity_dots", "intensity_background", "intensity_target")
-)
 
 
 def dotted(
@@ -530,6 +522,26 @@ def dotted(
     return stim
 
 
+basic_two_sided = make_two_sided(
+    basic, two_sided_params=("target_size", "intensity_target", "intensity_background")
+)
+
+
+square_two_sided = make_two_sided(
+    square, two_sided_params=("target_radius", "surround_radius", "rotation", "intensity_target", "intensity_surround", "intensity_background")
+)
+
+
+circular_two_sided = make_two_sided(
+    circular, two_sided_params=("target_radius", "surround_radius", "intensity_target", "intensity_surround", "intensity_background")
+)
+
+
+with_dots_two_sided = make_two_sided(
+    with_dots, two_sided_params=("intensity_dots", "intensity_background", "intensity_target")
+)
+
+
 dotted_two_sided = make_two_sided(
     dotted, two_sided_params=("intensity_target", "intensity_background", "intensity_dots")
 )
@@ -561,11 +573,13 @@ def overview(**kwargs):
         "sbc_basic": basic(**default_params, visual_size=10, target_size=3),
         "sbc_square": square(**default_params, visual_size=10, target_radius=1, surround_radius=2),
         "sbc_circular": circular(**default_params, visual_size=10, target_radius=1, surround_radius=2),
+        "sbc_with_dots": with_dots(**default_params, **dot_params),
+        "sbc_dotted": dotted(**default_params, **dot_params),
 
         "sbc_2sided": basic_two_sided(**default_params, visual_size=10, target_size=2, intensity_background=(0.0, 1.0)),
-        "sbc_with_dots": with_dots(**default_params, **dot_params),
+        "sbc_square_2sided": square_two_sided(**default_params, visual_size=10, target_radius=1, surround_radius=2, intensity_surround=(1.0, 0.0)),
+        "sbc_circular_2sided": circular_two_sided(**default_params, visual_size=10, target_radius=1, surround_radius=2, intensity_surround=(1.0, 0.0)),
         "sbc_with_dots_2sided": with_dots_two_sided(**default_params, **dot_params, intensity_background=(0.0, 1.0), intensity_dots=(1.0, 0.0)),
-        "sbc_dotted": dotted(**default_params, **dot_params),
         "sbc_dotted_2sided": dotted_two_sided(**default_params, **dot_params, intensity_background=(0.0, 1.0), intensity_dots=(1.0, 0.0)),
     }
     # fmt: on

--- a/stimupy/stimuli/sbcs.py
+++ b/stimupy/stimuli/sbcs.py
@@ -528,12 +528,27 @@ basic_two_sided = make_two_sided(
 
 
 square_two_sided = make_two_sided(
-    square, two_sided_params=("target_radius", "surround_radius", "rotation", "intensity_target", "intensity_surround", "intensity_background")
+    square,
+    two_sided_params=(
+        "target_radius",
+        "surround_radius",
+        "rotation",
+        "intensity_target",
+        "intensity_surround",
+        "intensity_background",
+    ),
 )
 
 
 circular_two_sided = make_two_sided(
-    circular, two_sided_params=("target_radius", "surround_radius", "intensity_target", "intensity_surround", "intensity_background")
+    circular,
+    two_sided_params=(
+        "target_radius",
+        "surround_radius",
+        "intensity_target",
+        "intensity_surround",
+        "intensity_background",
+    ),
 )
 
 

--- a/stimupy/stimuli/sbcs.py
+++ b/stimupy/stimuli/sbcs.py
@@ -27,6 +27,7 @@ def generalized(
     target_position=None,
     intensity_background=0.0,
     intensity_target=0.5,
+    rotation=0.0,
 ):
     """Simultaneous contrast stimulus with free target placement
 
@@ -47,6 +48,9 @@ def generalized(
         intensity value for background, by default 0.0
     intensity_target : float, optional
         intensity value for target, by default 0.5
+    rotation : float, optional
+        rotation (in degrees), counterclockwise, by default 0.0 (horizonal)
+
 
     Returns
     -------
@@ -71,18 +75,14 @@ def generalized(
         rectangle_position=target_position,
         intensity_background=intensity_background,
         intensity_rectangle=intensity_target,
+        rotation=rotation,
     )
 
-    stim["target_mask"] = stim["rectangle_mask"]
-    stim["target_size"] = stim["rectangle_size"]
-    stim["target_position"] = stim["rectangle_position"]
-    stim["intensity_target"] = stim["intensity_rectangle"]
-    del (
-        stim["rectangle_mask"],
-        stim["rectangle_size"],
-        stim["rectangle_position"],
-        stim["intensity_rectangle"],
-    )
+    stim["target_mask"] = stim.pop("rectangle_mask")
+    stim["target_size"] = stim.pop("rectangle_size")
+    stim["target_position"] = stim.pop("rectangle_position")
+    stim["intensity_target"] = stim.pop("intensity_rectangle")
+
     return stim
 
 

--- a/stimupy/stimuli/sbcs.py
+++ b/stimupy/stimuli/sbcs.py
@@ -23,25 +23,25 @@ def generalized(
     intensity_background=0.0,
     intensity_target=0.5,
 ):
-    """Simultaneous contrast stimulus with free target placement.
+    """Simultaneous contrast stimulus with free target placement
 
     Parameters
     ----------
     visual_size : Sequence[Number, Number], Number, or None (default)
-        visual size [height, width] of grating, in degrees
+        visual size [height, width] of image, in degrees
     ppd : Sequence[Number, Number], Number, or None (default)
         pixels per degree [vertical, horizontal]
     shape : Sequence[Number, Number], Number, or None (default)
-        shape [height, width] of grating, in pixels
+        shape [height, width] of image, in pixels
     target_size : float or (float, float)
-        size of the target in degree visual angle (height, width)
+        size [height, width] of the target, in degrees visual angle
     target_position : float or (float, float)
         position of the target in degree visual angle (height, width);
         if None, place target centrally
-    intensity_background : float
-        intensity value for background
-    intensity_target : float
-        intensity value for target
+    intensity_background : float, optional
+        intensity value for background, by default 0.0
+    intensity_target : float, optional
+        intensity value for target, by default 0.5
 
     Returns
     -------
@@ -89,22 +89,22 @@ def basic(
     intensity_background=0.0,
     intensity_target=0.5,
 ):
-    """Simultaneous contrast stimulus with central target.
+    """Simultaneous contrast stimulus with central target
 
     Parameters
     ----------
     visual_size : Sequence[Number, Number], Number, or None (default)
-        visual size [height, width] of grating, in degrees
+        visual size [height, width] of image, in degrees
     ppd : Sequence[Number, Number], Number, or None (default)
         pixels per degree [vertical, horizontal]
     shape : Sequence[Number, Number], Number, or None (default)
-        shape [height, width] of grating, in pixels
+        shape [height, width] of image, in pixels
     target_size : float or (float, float)
-        size of the target in degree visual angle (height, width)
-    intensity_background : float
-        intensity value for background
-    intensity_target : float
-        intensity value for target
+        size [height, width] of the target, in degrees visual angle
+    intensity_background : float, optional
+        intensity value for background, by default 0.0
+    intensity_target : float, optional
+        intensity value for target, by default 0.5
 
     Returns
     -------
@@ -124,6 +124,7 @@ def basic(
     stim = generalized(
         visual_size=visual_size,
         ppd=ppd,
+        shape=shape,
         target_size=target_size,
         target_position=None,
         intensity_background=intensity_background,


### PR DESCRIPTION
Added some convenience `.sbcs.`-stimulus functions:
- `.square()`
- `.circular()`
These are based on the respective `bullseyes.`-functions, and thus ultimately o the `rings.`-functions. As such, they take `target_radius` and `surround_radius` arguments, similar to the bulleyes and rings, which allows for consistent specification of related stimuli.

Enabled `rotation` (#39) in:
- `sbcs.generalized`,
- `sbcs.square`,
- `sbcs.circular`,

Additionally, all the `sbcs.`-functions now have a corresponding `<>_two_sided()` variant.
These are now also used in several of the `papers.`-stimuli.