### PR TITLE
Fix(RHS2007): Individually mask each target in WE_Dual

### DIFF
--- a/stimupy/papers/RHS2007.py
+++ b/stimupy/papers/RHS2007.py
@@ -276,7 +276,7 @@ def WE_dual(ppd=PPD, pad=True):
     # Pad and stack
     stim1 = pad_dict_to_shape(stim1, shape, pad_value=v2)
     stim2 = pad_dict_to_shape(stim2, shape, pad_value=v2)
-    stim = stack_dicts(stim1, stim2, keep_mask_indices=True)
+    stim = stack_dicts(stim1, stim2, keep_mask_indices=False)
 
     params.update(
         visual_size=np.array(stim["img"].shape) / ppd,

--- a/tests/papers/RHS2007.json
+++ b/tests/papers/RHS2007.json
@@ -9,7 +9,7 @@
     },
     "WE_dual": {
         "img": "0eb7042718b74b8973d8e945f0454867",
-        "mask": "d6eff24ab36465877ff03f79da860e52"
+        "mask": "1cdb8e0c80fc90b36f061804a34616d1"
     },
     "WE_anderson": {
         "img": "c057361b1e23043ada45923cf73f9b98",


### PR DESCRIPTION
This stimulus has two separate White's illusions in the same image. Each illusion has one target collinear with a black bar, and one target collinear with a white bar. Thus, the stimulus also has 1 `target_mask` that indexes all pixels belonging to the targets.
Previously, both targets collinear with black were lumped together / given the same mask idx -- as were the targets in white. As a result, there was no (straightforward) way to compare just the targets in one illusion, without accessing the targets in the other illusion.
Now, each target has its own index value (`1`-`4`), and each target can thus be accessed independently.