### PR TITLE
fix: rounding to nearest values from list

### DIFF
--- a/stimupy/utils/utils.py
+++ b/stimupy/utils/utils.py
@@ -48,6 +48,13 @@ def round_to_vals(arr, vals, mode="nearest"):
     out_arr : np.ndarray
         Rounded output array
 
+    Raises
+    ------
+    ValueError
+        If `mode` is not one of ["nearest", "floor", "ceil"].
+        If `arr` contains values outside the bounds of
+        `vals` when `mode` is "floor" or "ceil".
+
     Examples
     --------
     >>> arr = np.array([1.1, 2.2, 3.3, 4.4, 5.5])
@@ -59,6 +66,16 @@ def round_to_vals(arr, vals, mode="nearest"):
     # Ensure the 1D array contains only unique values
     arr_1d = np.sort(np.unique(vals))
     arr = np.array(arr)
+
+    # Ensure arr fall within bounds of mode:
+    if mode == "floor" and arr.min() < arr_1d.min():
+        raise ValueError(
+            f"Array values must be within bounds of vals : {arr.min()} < {arr_1d.min()}"
+        )
+    if mode == "ceil" and arr.min() > arr_1d.max():
+        raise ValueError(
+            f"Array values must be within bounds of vals: {arr.min()} > {arr_1d.max()}"
+        )
 
     # Find the nearest values from vals, for each element in arr
     match mode:

--- a/stimupy/utils/utils.py
+++ b/stimupy/utils/utils.py
@@ -43,16 +43,13 @@ def round_to_vals(arr, vals):
         Rounded output array
 
     """
-    n_val = len(vals)
-    arr = np.repeat(np.expand_dims(arr, -1), n_val, axis=2)
-    vals_arr = np.ones(arr.shape) * np.array(np.expand_dims(vals, [0, 1]))
-
-    indices = np.argmin(np.abs(arr - vals_arr), axis=2)
-    out_arr = np.copy(indices).astype(float)
-
-    for i in range(n_val):
-        out_arr[indices == i] = vals[i]
-    return out_arr
+    # Ensure the 1D array contains unique values
+    arr_1d = np.unique(vals)
+    
+    # Find the nearest values from arr_1d for each element in arr
+    rounded_arr = np.array([arr_1d[np.abs(arr_1d - x).argmin()] for x in arr.ravel()]).reshape(arr.shape)
+    
+    return rounded_arr
 
 
 def int_factorize(n):

--- a/stimupy/utils/utils.py
+++ b/stimupy/utils/utils.py
@@ -27,20 +27,31 @@ __all__ = [
 
 
 def round_to_vals(arr, vals):
-    """
-    Round array to provided values (vals)
+    """Round each element of array to closest match in provided values
+
+    For each element in the input `arr`, find the closest value from the provided `vals`
+    and replace the element with this closest value.
+    If the element is equidistant to two values, the smaller
+    value is chosen.
 
     Parameters
     ----------
     arr : np.ndarray
-        Numpy array which values will be rounded
+        array to be rounded
     vals : Sequence(float, ...)
-        Values to which array will be rounded
+        values to which array will be rounded
 
     Returns
     -------
     out_arr : np.ndarray
         Rounded output array
+
+    Examples
+    --------
+    >>> arr = np.array([1.1, 2.2, 3.3, 4.4, 5.5])
+    >>> vals = [1, 3, 5]
+    >>> round_to_vals(arr, vals)
+    array([1., 3., 3., 5., 5.])
 
     """
     # Ensure the 1D array contains only unique values

--- a/stimupy/utils/utils.py
+++ b/stimupy/utils/utils.py
@@ -45,10 +45,12 @@ def round_to_vals(arr, vals):
     """
     # Ensure the 1D array contains unique values
     arr_1d = np.unique(vals)
-    
+
     # Find the nearest values from arr_1d for each element in arr
-    rounded_arr = np.array([arr_1d[np.abs(arr_1d - x).argmin()] for x in arr.ravel()]).reshape(arr.shape)
-    
+    rounded_arr = np.array([arr_1d[np.abs(arr_1d - x).argmin()] for x in arr.ravel()]).reshape(
+        arr.shape
+    )
+
     return rounded_arr
 
 

--- a/stimupy/utils/utils.py
+++ b/stimupy/utils/utils.py
@@ -43,13 +43,21 @@ def round_to_vals(arr, vals):
         Rounded output array
 
     """
-    # Ensure the 1D array contains unique values
-    arr_1d = np.unique(vals)
+    # Ensure the 1D array contains only unique values
+    arr_1d = np.sort(np.unique(vals))
 
-    # Find the nearest values from arr_1d for each element in arr
-    rounded_arr = np.array([arr_1d[np.abs(arr_1d - x).argmin()] for x in arr.ravel()]).reshape(
-        arr.shape
+    # Find the nearest values from vals, for each element in arr
+    idxs = np.searchsorted(arr_1d, arr, side="left")
+
+    # Find indexes where previous index is closer
+    prev_idx_is_less = (idxs == len(arr_1d)) | (
+        np.fabs(arr - arr_1d[np.maximum(idxs - 1, 0)])
+        < np.fabs(arr - arr_1d[np.minimum(idxs, len(arr_1d) - 1)])
     )
+    idxs[prev_idx_is_less] -= 1
+
+    # Replace each element in arr with the nearest value from vals
+    rounded_arr = arr_1d[idxs]
 
     return rounded_arr
 

--- a/stimupy/utils/utils.py
+++ b/stimupy/utils/utils.py
@@ -78,21 +78,20 @@ def round_to_vals(arr, vals, mode="nearest"):
         )
 
     # Find the nearest values from vals, for each element in arr
-    match mode:
-        case "floor":
-            idxs = np.searchsorted(arr_1d, arr, side="left") - 1
-        case "ceil":
-            idxs = np.searchsorted(arr_1d, arr, side="right")
-        case "nearest":
-            # Find indexes where previous index is closer
-            idxs = np.searchsorted(arr_1d, arr, side="left")
-            prev_idx_is_less = (idxs == len(arr_1d)) | (
-                np.fabs(arr - arr_1d[np.maximum(idxs - 1, 0)])
-                < np.fabs(arr - arr_1d[np.minimum(idxs, len(arr_1d) - 1)])
-            )
-            idxs[prev_idx_is_less] -= 1
-        case _:
-            raise ValueError(f"Invalid mode: {mode}")
+    if mode == "floor":
+        idxs = np.searchsorted(arr_1d, arr, side="left") - 1
+    elif mode == "ceil":
+        idxs = np.searchsorted(arr_1d, arr, side="right")
+    elif mode == "nearest":
+        # Find indexes where previous index is closer
+        idxs = np.searchsorted(arr_1d, arr, side="left")
+        prev_idx_is_less = (idxs == len(arr_1d)) | (
+            np.fabs(arr - arr_1d[np.maximum(idxs - 1, 0)])
+            < np.fabs(arr - arr_1d[np.minimum(idxs, len(arr_1d) - 1)])
+        )
+        idxs[prev_idx_is_less] -= 1
+    else:
+        raise ValueError(f"Invalid mode: {mode}")
 
     # Replace each element in arr with the nearest value from vals
     rounded_arr = arr_1d[idxs]

--- a/tests/test_rounding.py
+++ b/tests/test_rounding.py
@@ -1,0 +1,15 @@
+import numpy as np
+import pytest
+
+from stimupy.utils import round_to_vals
+
+rng = np.random.default_rng()
+
+
+@pytest.mark.parametrize("size", [10, 100, 1000, 10000])
+@pytest.mark.parametrize("n_vals", [5, 50, 500])
+def test_rounding(size, n_vals):
+    arr = rng.uniform(0, 1000, (size, size))
+    vals = rng.integers(0, 1000, n_vals)
+    rounded_arr = round_to_vals(arr, vals)
+    assert np.all(np.isin(rounded_arr, vals))

--- a/tests/test_rounding.py
+++ b/tests/test_rounding.py
@@ -22,3 +22,9 @@ def test_rounding(size, n_vals, mode):
             assert np.all(rounded_arr >= arr)
 
 
+def test_raises_oob():
+    with pytest.raises(ValueError):
+        round_to_vals([0], [1, 2], "floor")
+
+    with pytest.raises(ValueError):
+        round_to_vals([3], [1, 2], "ceil")

--- a/tests/test_rounding.py
+++ b/tests/test_rounding.py
@@ -15,11 +15,10 @@ def test_rounding(size, n_vals, mode):
     rounded_arr = round_to_vals(arr, vals, mode)
 
     assert np.all(np.isin(rounded_arr, vals))
-    match mode:
-        case "floor":
-            assert np.all(rounded_arr <= arr)
-        case "ceil":
-            assert np.all(rounded_arr >= arr)
+    if mode == "floor":
+        assert np.all(rounded_arr <= arr)
+    elif mode == "ceil":
+        assert np.all(rounded_arr >= arr)
 
 
 def test_raises_oob():

--- a/tests/test_rounding.py
+++ b/tests/test_rounding.py
@@ -8,8 +8,17 @@ rng = np.random.default_rng()
 
 @pytest.mark.parametrize("size", [10, 100, 1000, 10000])
 @pytest.mark.parametrize("n_vals", [5, 50, 500])
-def test_rounding(size, n_vals):
-    arr = rng.uniform(0, 1000, (size, size))
+@pytest.mark.parametrize("mode", ["nearest", "floor", "ceil"])
+def test_rounding(size, n_vals, mode):
     vals = rng.integers(0, 1000, n_vals)
-    rounded_arr = round_to_vals(arr, vals)
+    arr = rng.uniform(vals.min(), vals.max(), (size, size))
+    rounded_arr = round_to_vals(arr, vals, mode)
+
     assert np.all(np.isin(rounded_arr, vals))
+    match mode:
+        case "floor":
+            assert np.all(rounded_arr <= arr)
+        case "ceil":
+            assert np.all(rounded_arr >= arr)
+
+


### PR DESCRIPTION
Improved utils rounding function that is efficient yet not as memory-heavy as the previous version