### PR TITLE
fix: `edges` deal with shape argument properly

### DIFF
--- a/stimupy/components/edges.py
+++ b/stimupy/components/edges.py
@@ -49,9 +49,9 @@ def step(
         origin="corner",
     )
 
-    img = np.ones(shape) * intensity_edges[0]
+    img = np.ones(base["shape"]) * intensity_edges[0]
     img = np.where(base["oblique"] < base["oblique"].mean(), img, intensity_edges[1])
-    mask = np.ones(shape)
+    mask = np.ones(base["shape"])
     mask = np.where(base["oblique"] < base["oblique"].mean(), mask, 2)
 
     stim = {


### PR DESCRIPTION
Issue which properly snuck in with a new version of NumPy?