### PR TITLE
Specify random number generator in noise texture generation

### DIFF
--- a/stimupy/noises/__init__.py
+++ b/stimupy/noises/__init__.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def randomize_sign(array):
+def randomize_sign(array, rng=None):
     """Randomize the sign of values in an array
 
     Parameters
@@ -15,7 +15,9 @@ def randomize_sign(array):
         Same array with randomized signs
 
     """
-    sign = np.random.rand(*array.shape) - 0.5
+    if rng is None:
+        rng = np.random.default_rng()
+    sign = rng.random(array.shape) - 0.5
     sign[sign <= 0.0] = -1.0
     sign[sign > 0.0] = 1.0
     array = array * sign
@@ -25,6 +27,7 @@ def randomize_sign(array):
 def pseudo_white_helper(
     shape,
     amplitude,
+    rng=None,
 ):
     """Generate pseudorandom white noise patch
 
@@ -44,9 +47,11 @@ def pseudo_white_helper(
     if isinstance(shape, (float, int)):
         shape = (shape, shape)
 
-    Re = np.random.rand(*shape) * amplitude - amplitude / 2.0
+    if rng is None:
+        rng = np.random.default_rng()
+    Re = rng.random(shape) * amplitude - amplitude / 2.0
     Im = np.sqrt((amplitude / 2.0) ** 2 - Re**2)
-    Im = randomize_sign(Im)
+    Im = randomize_sign(Im, rng=rng)
     output = Re + Im * 1j
     return output
 
@@ -54,6 +59,7 @@ def pseudo_white_helper(
 def pseudo_white_spectrum(
     shape=(100, 100),
     amplitude=2.0,
+    rng=None,
 ):
     """Create pseudorandom white noise spectrum
 
@@ -85,8 +91,8 @@ def pseudo_white_spectrum(
         raise ValueError("shape needs to be even-numbered")
 
     # We divide the noise spectrum in four quadrants with pseudorandom white noise
-    quadrant1 = pseudo_white_helper((int(y / 2) - 1, int(x / 2) - 1), A)
-    quadrant2 = pseudo_white_helper((int(y / 2) - 1, int(x / 2) - 1), A)
+    quadrant1 = pseudo_white_helper((int(y / 2) - 1, int(x / 2) - 1), A, rng=rng)
+    quadrant2 = pseudo_white_helper((int(y / 2) - 1, int(x / 2) - 1), A, rng=rng)
     quadrant3 = quadrant2[::-1, ::-1].conj()
     quadrant4 = quadrant1[::-1, ::-1].conj()
 
@@ -100,25 +106,25 @@ def pseudo_white_spectrum(
 
     # We need to fill the rows / columns that the quadrants do not cover
     # Fill first row:
-    row = pseudo_white_helper((1, x), A)
+    row = pseudo_white_helper((1, x), A, rng=rng)
     apu = np.fliplr(row)
     row[0, int(x / 2 + 1) : x] = apu[0, int(x / 2) : x - 1].conj()
     spectrum[0, :] = np.squeeze(row)
 
     # Fill central row:
-    row = pseudo_white_helper((1, x), A)
+    row = pseudo_white_helper((1, x), A, rng=rng)
     apu = np.fliplr(row)
     row[0, int(x / 2 + 1) : x] = apu[0, int(x / 2) : x - 1].conj()
     spectrum[int(y / 2), :] = np.squeeze(row)
 
     # Fill first column:
-    col = pseudo_white_helper((y, 1), A)
+    col = pseudo_white_helper((y, 1), A, rng=rng)
     apu = np.flipud(col)
     col[int(y / 2 + 1) : y, 0] = apu[int(y / 2) : y - 1, 0].conj()
     spectrum[:, int(x / 2)] = np.squeeze(col)
 
     # Fill central column:
-    col = pseudo_white_helper((y, 1), A)
+    col = pseudo_white_helper((y, 1), A, rng=rng)
     apu = np.flipud(col)
     col[int(y / 2 + 1) : y, 0] = apu[int(y / 2) : y - 1, 0].conj()
     spectrum[:, 0] = np.squeeze(col)
@@ -131,6 +137,7 @@ def pseudo_white_spectrum(
     # Set DC = 0:
     spectrum[int(y / 2), int(x / 2)] = 0 + 0j
     return spectrum
+
 
 # flake8: noqa: E402
 from stimupy.noises import binaries, narrowbands, naturals, whites

--- a/stimupy/noises/binaries.py
+++ b/stimupy/noises/binaries.py
@@ -13,6 +13,7 @@ def binary(
     ppd=None,
     shape=None,
     intensity_range=(0, 1),
+    rng=None,
 ):
     """Draw binary noise texture
 
@@ -27,6 +28,8 @@ def binary(
     intensity_range : Sequence[Number, Number]
         minimum and maximum intensity value; default: (0, 1).
         be aware that not every instance has mean=(max-min)/2.
+    rng : numpy.random.Generator, optional
+        Random number generator instance
 
     Returns
     -------
@@ -40,7 +43,9 @@ def binary(
     if len(np.unique(ppd)) > 1:
         raise ValueError("ppd should be equal in x and y direction")
 
-    binary_noise = np.random.randint(0, 2, size=shape) - 0.5
+    if rng is None:
+        rng = np.random.default_rng()
+    binary_noise = rng.integers(0, 2, size=shape) - 0.5
 
     # Adjust intensity range:
     binary_noise = adapt_intensity_range(binary_noise, intensity_range[0], intensity_range[1])

--- a/stimupy/noises/narrowbands.py
+++ b/stimupy/noises/narrowbands.py
@@ -17,6 +17,7 @@ def narrowband(
     bandwidth=None,
     intensity_range=(0, 1),
     pseudo_noise=False,
+    rng=None,
 ):
     """Draw narrowband noise texture
 
@@ -59,12 +60,14 @@ def narrowband(
         visual_size=visual_size, ppd=ppd, center_frequency=center_frequency, bandwidth=bandwidth
     )["img"]
 
+    if rng is None:
+        rng = np.random.default_rng()
     if pseudo_noise:
         # Create white noise with frequency amplitude of 1 everywhere
-        white_noise_fft = pseudo_white_spectrum(shape)
+        white_noise_fft = pseudo_white_spectrum(shape, rng=rng)
     else:
         # Create white noise and fft
-        white_noise = np.random.rand(*shape) * 2.0 - 1.0
+        white_noise = rng.random(shape) * 2.0 - 1.0
         white_noise_fft = np.fft.fftshift(np.fft.fft2(white_noise))
 
     # Filter white noise with bandpass filter

--- a/stimupy/noises/naturals.py
+++ b/stimupy/noises/naturals.py
@@ -18,6 +18,7 @@ def one_over_f(
     exponent=None,
     intensity_range=(0, 1),
     pseudo_noise=False,
+    rng=None,
 ):
     """Draw 1 / (f**exponent) noise texture
 
@@ -61,12 +62,14 @@ def one_over_f(
     f = f**exponent
     f[f == 0.0] = 1.0  # Prevent division by zero (DC is zero anyways)
 
+    if rng is None:
+        rng = np.random.default_rng()
     if pseudo_noise:
         # Create white noise with frequency amplitude of 1 everywhere
-        white_noise_fft = pseudo_white_spectrum(shape)
+        white_noise_fft = pseudo_white_spectrum(shape, rng=rng)
     else:
         # Create white noise and fft
-        white_noise = np.random.rand(*shape) * 2.0 - 1.0
+        white_noise = rng.random(shape) * 2.0 - 1.0
         white_noise_fft = np.fft.fftshift(np.fft.fft2(white_noise))
 
     # Create 1/f noise:
@@ -98,6 +101,7 @@ def pink(
     shape=None,
     intensity_range=(0, 1),
     pseudo_noise=False,
+    rng=None,
 ):
     """Draw pink (1 / f) noise texture
 
@@ -126,6 +130,7 @@ def pink(
         exponent=1.0,
         intensity_range=intensity_range,
         pseudo_noise=pseudo_noise,
+        rng=rng,
     )
     return stim
 
@@ -136,6 +141,7 @@ def brown(
     shape=None,
     intensity_range=(0, 1),
     pseudo_noise=False,
+    rng=None,
 ):
     """Draw brown (1 / (f**2.0)) noise texture
 
@@ -164,6 +170,7 @@ def brown(
         exponent=2.0,
         intensity_range=intensity_range,
         pseudo_noise=pseudo_noise,
+        rng=rng,
     )
     return stim
 

--- a/stimupy/noises/whites.py
+++ b/stimupy/noises/whites.py
@@ -15,6 +15,7 @@ def white(
     shape=None,
     intensity_range=(0, 1),
     pseudo_noise=False,
+    rng=None,
 ):
     """Draw white noise texture
 
@@ -42,16 +43,18 @@ def white(
     if len(np.unique(ppd)) > 1:
         raise ValueError("ppd should be equal in x and y direction")
 
+    if rng is None:
+        rng = np.random.default_rng()
     if pseudo_noise:
         # Create white noise with frequency amplitude of 1 everywhere
-        white_noise_fft = pseudo_white_spectrum(shape)
+        white_noise_fft = pseudo_white_spectrum(shape, rng=rng)
 
         # ifft
         white_noise = np.fft.ifft2(np.fft.ifftshift(white_noise_fft))
         white_noise = np.real(white_noise)
     else:
         # Create white noise and fft
-        white_noise = np.random.rand(*shape) * 2.0 - 1.0
+        white_noise = rng.random(shape) * 2.0 - 1.0
 
     # Adjust intensity range:
     white_noise = adapt_intensity_range(white_noise, intensity_range[0], intensity_range[1])

--- a/tests/papers/gen_ground_truth.py
+++ b/tests/papers/gen_ground_truth.py
@@ -15,6 +15,20 @@ for paper in papers:
     stims = paper_module.gen_all(skip=True)
 
     # Convert "img", "mask" to checksums
+    import numpy as np
+
+    for stim_name, stim in stims.items():
+        # Pass a fixed RNG to each stimulus function if possible
+        rng = np.random.default_rng(42)
+        if hasattr(paper_module, stim_name):
+            func = getattr(paper_module, stim_name)
+            try:
+                stim = func(rng=rng)
+            except TypeError:
+                # Fallback if function does not accept rng
+                stim = func()
+            stims[stim_name] = stim
+
     for stim in stims.values():
         img = stim["img"]
 

--- a/tests/test_noises.py
+++ b/tests/test_noises.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+
+from stimupy.noises import binaries, narrowbands, naturals, whites
+
+
+def get_noise_functions():
+    return [
+        binaries.binary,
+        narrowbands.narrowband,
+        naturals.one_over_f,
+        naturals.pink,
+        naturals.brown,
+        whites.white,
+    ]
+
+
+@pytest.mark.parametrize("func", get_noise_functions())
+def test_noise_reproducibility(func):
+    # Create a fixed RNG
+    seed = 12345
+    rng1 = np.random.default_rng(seed)
+    rng2 = np.random.default_rng(seed)
+
+    # Minimal required arguments for each function
+    kwargs = {
+        "ppd": 32,
+        "visual_size": 10,
+    }
+    # Some functions require extra args
+    if func is narrowbands.narrowband:
+        kwargs.update({"center_frequency": 2, "bandwidth": 1})
+    if func is naturals.one_over_f:
+        kwargs.update({"exponent": 1.0})
+
+    # Call twice with two RNGs
+    stim1 = func(rng=rng1, **kwargs)
+    stim2 = func(rng=rng2, **kwargs)
+
+    # Compare outputs
+    np.testing.assert_allclose(stim1["img"], stim2["img"], atol=1e-12)


### PR DESCRIPTION
By optionally passing in a NumPy random number generator, one can control the stochastic process underlying the noise texture generation. Thus, to make replicable noise textures, simply pass a fresh RNG with a specified seed, and the resulting texture should always be the same.

Also provided some tests for this.