### PR TITLE
build: support `py>=3.14`, on Ubuntu and Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [Ubuntu, macOS]
+        os: [Ubuntu, Windows]
         python_version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
         # Checkout the stimupy repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [Ubuntu, Windows]
-        python_version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python_version: ['3.10', '3.11', '3.12', '3.13']
     steps:
         # Checkout the stimupy repository
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [Ubuntu, Windows]
-        python_version: ['3.10', '3.11', '3.12', '3.13']
+        python_version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
         # Checkout the stimupy repository
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ maintainers = [
 version = "1.2.0"
 
 requires-python = ">=3.10"
-dependencies = ["numpy<2.3", "scipy", "matplotlib", "pandas", "Pillow"]
+dependencies = ["numpy", "scipy", "matplotlib", "pandas", "Pillow"]
 
 [dependency-groups]
 test = ["pytest"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ maintainers = [
 ]
 version = "1.2.0"
 
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = ["numpy<2.3", "scipy", "matplotlib", "pandas", "Pillow"]
 
 [dependency-groups]

--- a/stimupy/stimuli/__init__.py
+++ b/stimupy/stimuli/__init__.py
@@ -1,4 +1,3 @@
-import itertools
 import logging
 
 import numpy as np
@@ -116,13 +115,26 @@ def place_targets(stim, element_mask_key, target_indices, intensity_target=0.5):
     stim["target_mask"] = mask_targets(
         element_mask=stim[element_mask_key], target_indices=target_indices
     )
+    n_targets = int(stim["target_mask"].max())
 
+    # Determine intensity for each target region
     if isinstance(intensity_target, (int, float)):
         intensity_target = [
             intensity_target,
         ]
-    intensity_target = itertools.cycle(intensity_target)
+    else:
+        intensity_target = list(intensity_target)
 
+    if n_targets > 0:
+        if len(intensity_target) == 0:
+            raise ValueError("intensity_target must not be empty when targets are requested")
+        intensity_target = [
+            intensity_target[idx % len(intensity_target)] for idx in range(n_targets)
+        ]
+    else:
+        intensity_target = []
+
+    # Place targets
     stim["img"] = np.where(
         stim["target_mask"],
         draw_regions(

--- a/stimupy/stimuli/benarys.py
+++ b/stimupy/stimuli/benarys.py
@@ -92,7 +92,7 @@ def cross_generalized(
     # Add targets
     stim = add_targets(
         cross_stim["img"],
-        np.unique(ppd),
+        np.unique(ppd).squeeze(),
         target_size,
         target_type,
         target_rotation,
@@ -365,7 +365,9 @@ def todorovic_generalized(
         raise ValueError("L_width cannot be larger than stimulus_width / 2")
 
     L_size = (visual_size[0] / 2, visual_size[0] / 2, L_width, visual_size[1] - L_width)
-    top, bottom, left, right = resolution.lengths_from_visual_angles_ppd(L_size, np.unique(ppd))
+    top, bottom, left, right = resolution.lengths_from_visual_angles_ppd(
+        L_size, np.unique(ppd).squeeze()
+    )
     width, height = left + right, top + bottom
 
     # Create stimulus without targets
@@ -377,7 +379,7 @@ def todorovic_generalized(
     # Add targets
     stim = add_targets(
         img,
-        np.unique(ppd),
+        np.unique(ppd).squeeze(),
         target_size,
         target_type,
         target_rotation,

--- a/stimupy/utils/resolution.py
+++ b/stimupy/utils/resolution.py
@@ -342,7 +342,7 @@ def length_from_visual_angle_ppd(visual_angle, ppd, round=True):
     visual angle (degrees) translated to length (pixels)
     """
     if visual_angle is not None and ppd is not None:
-        fpix = np.round(visual_angle * ppd, 10)
+        fpix = np.round(visual_angle * ppd, 10).squeeze()
 
         if round:
             pix = int(fpix)


### PR DESCRIPTION
A few fixes to bring `stimupy` up to date with python 3.14, numpy 2.3+